### PR TITLE
Add example after intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,21 @@ DRAFT: JSX Specification
 
 JSX is a XML-like syntax extension to ECMAScript without any defined semantics. It's NOT intended to be implemented by engines or browsers. It's intended to be used by various preprocessors (transpilers) to transform these tokens into standard ECMAScript.
 
+```
+// Using JSX to express UI components.
+var dropdown =
+  <Dropdown>
+    A dropdown list
+    <Menu>
+      <MenuItem>Do Something</MenuItem>
+      <MenuItem>Do Something Fun!</MenuItem>
+      <MenuItem>Do Something Else</MenuItem>
+    </Menu>
+  </DropDown>;
+
+render(dropdown);
+```
+
 Rationale
 ---------
 


### PR DESCRIPTION
As discussed with @sebmarkbage we should have a concrete example at the top of the page so people can get an idea of what JSX can be used for.
While I understand that this page is primarily a spec, it still could end up ranking high in search and would be pretty bad marketing if people bounced more confused than they came in.
