### PR TITLE
Attribute spec fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,16 +83,12 @@ __Attributes__
 
 JSXAttributes : 
 
-- JSXSpreadAttribute JSXAttributes<sub>opt</sub>
 - JSXAttribute JSXAttributes<sub>opt</sub>
-
-JSXSpreadAttribute :
-
-- `{` `...` AssignmentExpression `}`
 
 JSXAttribute : 
 
 - JSXAttributeName `=` JSXAttributeValue
+- JSXSpreadAttribute
 
 JSXAttributeName :
 
@@ -104,6 +100,11 @@ JSXAttributeValue : 
 - `"` JSXDoubleStringCharacters<sub>opt</sub> `"`
 - `'` JSXSingleStringCharacters<sub>opt</sub> `'`
 - `{` AssignmentExpression `}`
+- JSXElement
+
+JSXSpreadAttribute :
+
+- `{` `...` AssignmentExpression `}`
 
 JSXDoubleStringCharacters : 
 


### PR DESCRIPTION
- JSXAttributeValue can be JSXElement (supported both in Esprima-FB and Acorn-JSX and reflected in tests).
- JSXSpreadAttribute is "subclass" of JSXAttribute. That also simplified JSXAttributes (list) rule.
