### PR TITLE
Small rule simplifications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ JSXChild :
 
 - JSXText
 - JSXElement
-- `{` `}`
-- `{` AssignmentExpression `}`
+- `{` AssignmentExpression<sub>opt</sub> `}`
 
 JSXText :
 
@@ -144,7 +143,7 @@ JSXTextCharacter :
 
 __Whitespace and Comments__
 
-_JSX uses the same punctuators and braces as ECMAScript. WhiteSpace, LineTerminators and Comments are generally allowed between any punctuator or brace._
+_JSX uses the same punctuators and braces as ECMAScript. WhiteSpace, LineTerminators and Comments are generally allowed between any punctuators._
 
 Parser Implementations
 ----------------------


### PR DESCRIPTION
- `{}` is subcase of `{ ...expression... }` with optional expression.
- Brace is also a punctuation character, so no need to specify explicitly.
