### PR TITLE
Clear up terminology around tags and elements

### DIFF
--- a/AST.md
+++ b/AST.md
@@ -56,31 +56,45 @@ interface JSXExpressionContainer <: Node {
 }
 ```
 
-JSX Boundary Tags
------------------
+JSX Element
+-----------
 
-Any JSX element is bounded by tags &mdash; either self-closing or both opening and closing elements:
+A JSX element consists of a start tag, a list of children, and an optional end tag:
 
 ```
-interface JSXBoundaryElement <: Node {
+interface JSXElement <: Expression {
+    type: "JSXElement",
+    startTag: JSXStartTag,
+    children: [ Literal | JSXExpressionContainer | JSXElement ],
+    endTag: JSXEndTag | null
+}
+```
+
+JSX Tags
+-----------------
+
+Any JSX element is delimited by tags &mdash; either self-closing or both start and end tags:
+
+```
+interface JSXTag <: Node {
     name: JSXIdentifier | JSXMemberExpression | JSXNamespacedName;
 }
 
-interface JSXOpeningElement <: JSXBoundaryElement {
-    type: "JSXOpeningElement",
+interface JSXStartTag <: JSXTag {
+    type: "JSXStartTag",
     attributes: [ JSXAttribute | JSXSpreadAttribute ],
     selfClosing: boolean;
 }
 
-interface JSXClosingElement <: JSXBoundaryElement {
-    type: "JSXClosingElement"
+interface JSXEndTag <: JSXTag {
+    type: "JSXEndTag"
 }
 ```
 
 JSX Attributes
 --------------
 
-Opening element ("tag") may contain attributes:
+Start tags may contain attributes:
 
 ```
 interface JSXAttribute <: Node {
@@ -98,20 +112,6 @@ interface SpreadElement <: Node {
 
 interface JSXSpreadAttribute <: SpreadElement {
     type: "JSXSpreadAttribute";
-}
-```
-
-JSX Element
------------
-
-Finally, JSX element itself consists of opening element, list of children and optional closing element:
-
-```
-interface JSXElement <: Expression {
-    type: "JSXElement",
-    openingElement: JSXOpeningElement,
-    children: [ Literal | JSXExpressionContainer | JSXElement ],
-    closingElement: JSXClosingElement | null
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,20 +45,20 @@ __Elements__
 JSXElement : 
 
 - JSXSelfClosingElement 
-- JSXOpeningElement JSXChildren<sub>opt</sub> JSXClosingElement<br />
-  (names of JSXOpeningElement and JSXClosingElement should match)
+- JSXStartTag JSXChildren<sub>opt</sub> JSXEndTag<br />
+  (names of JSXStartTag and JSXEndTag should match)
 
 JSXSelfClosingElement :
 
-- `<` JSXElementName JSXAttributes<sub>opt</sub> `/` `>`
+- `<` JSXElementName JSXAttributes<sub>opt</sub> `/>`
 
-JSXOpeningElement :
+JSXStartTag :
 
 - `<` JSXElementName JSXAttributes<sub>opt</sub> `>`
 
-JSXClosingElement :
+JSXEndTag :
 
-- `<` `/` JSXElementName `>`
+- `</` JSXElementName `>`
 
 JSXElementName :
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ JSXElement : 
 
 JSXSelfClosingElement :
 
-- `<` JSXElementName JSXAttributes<sub>opt</sub> `/>`
+- `<` JSXElementName JSXAttributes<sub>opt</sub> `/` `>`
 
 JSXStartTag :
 
@@ -58,7 +58,7 @@ JSXStartTag :
 
 JSXEndTag :
 
-- `</` JSXElementName `>`
+- `<` `/` JSXElementName `>`
 
 JSXElementName :
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ JSXElement : 
 
 - JSXSelfClosingElement 
 - JSXStartTag JSXChildren<sub>opt</sub> JSXEndTag<br />
-  (names of JSXStartTag and JSXEndTag should match)
+  (names of JSXStartTag and JSXEndTag must match)
 
 JSXSelfClosingElement :
 


### PR DESCRIPTION
Hey.

I know that JSX is not XML, but since it's inspired, it makes sense to use the same terminology as far as possible.
There is no such thing as an "opening element" or a "closing element". There are "start tags" and "end tags" that delimit elements. There are also some wording fixes, and I moved the "JSX Elements" section up before tags and attributes in AST.md.