### PR TITLE
Add JSXAttributeInitializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,16 @@ JSXSpreadAttribute :
 
 JSXAttribute : 
 
-- JSXAttributeName `=` JSXAttributeValue
+- JSXAttributeName JSXAttributeInitializer<sub>opt</sub>
 
 JSXAttributeName :
 
 - JSXIdentifier
 - JSXNamespacedName
+
+JSXAttributeInitializer : 
+
+- `=` JSXAttributeValue
 
 JSXAttributeValue : 
 


### PR DESCRIPTION
Support for boolean attributes (e.g. `<X y />` vs `<X y={true} />`) is already advertised ([JSX in Depth](https://facebook.github.io/react/docs/jsx-in-depth.html#boolean-attributes), https://github.com/facebook/react/issues/2536#issuecomment-64830878) and implemented (e.g. Babel), so I'm thinking it should be reflected here?