### PR TITLE
Add JSXNamespacedName to object of JSXMemberExpression

### DIFF
--- a/AST.md
+++ b/AST.md
@@ -21,7 +21,7 @@ Property-like namespace syntax (tag names only):
 ```js
 interface JSXMemberExpression <: Expression {
     type: "JSXMemberExpression";
-    object: JSXMemberExpression | JSXIdentifier,
+    object: JSXIdentifier | JSXMemberExpression | JSXNamespacedName,
     property: JSXIdentifier
 }
 ```


### PR DESCRIPTION
Following JSX makes JSXNamespacedName as an object of JSXMemberExpression.
```jsx
<n:v.p />
```
https://astexplorer.net/#/Vy64XFydgx

```json
      {
        "type": "JSXElement",
        "start": 0,
        "end": 14,
        "openingElement": {
          "type": "JSXOpeningElement",
          "start": 0,
          "end": 14,
          "attributes": [],
          "name": {
            "type": "JSXMemberExpression",
            "start": 1,
            "end": 11,
            "object": {
              "type": "JSXMemberExpression",
              "start": 1,
              "end": 8,
              "object": {
                "type": "JSXNamespacedName",
                "start": 1,
                "end": 5,
                "namespace": {
                  "type": "JSXIdentifier",
                  "start": 1,
                  "end": 2,
                  "name": "n"
                },
                "name": {
                  "type": "JSXIdentifier",
                  "start": 3,
                  "end": 5,
                  "name": "v1"
                }
              },
              "property": {
                "type": "JSXIdentifier",
                "start": 6,
                "end": 8,
                "name": "v2"
              }
            },
            "property": {
              "type": "JSXIdentifier",
              "start": 9,
              "end": 11,
              "name": "v3"
            }
          },
          "selfClosing": true
        },
        "closingElement": null,
        "children": []
      }
```