### PR TITLE
adding Jade like compact indented JSX syntax via option in babel parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ var dropdown =
 
 render(dropdown);
 ```
+Indented Mode
+```
+// Using JSX to express UI components.
+var dropdown =
+  <Dropdown>
+    A dropdown list
+    <Menu>
+      <MenuItem>Do Something
+      <MenuItem>Do Something Fun!
+      <MenuItem>Do Something Else
+      
+render(dropdown);
+```
+------
 
 Rationale
 ---------


### PR DESCRIPTION
This PR comes from a conversation in babel/babylon#61 where I proposed adding the ability to use compact indented JSX syntax via option. I implemented indented mode plus tests in Jsx Parser in babel/babylon#61 and also in fork of acorn-jsx. indented mode is activated via parser indented:true,locations:true options . There are no changes to normal Jsx control-flow/state. For the full rationale see that issue, here’s an abridged version: What you guys think ? If compact jsx mode is too crazy than I appologize I just lost job and all of the sudden got creative ;D and such 

~~~~~~html
var App  =  <div>
                <drawer> 
                    <menu>
                        <item>
                <area>
                    <toolbar>
                    <content>
~~~~~~