### PR TITLE
Add JSXText node definition

### DIFF
--- a/AST.md
+++ b/AST.md
@@ -110,6 +110,19 @@ interface JSXSpreadAttribute <: SpreadElement {
 }
 ```
 
+JSX Text
+--------
+
+JSX Text node stores a string literal found in JSX element children.
+
+```js
+interface JSXText <: Node {
+  type: "JSXText"
+  value: string,
+  raw: string
+}
+```
+
 JSX Element
 -----------
 


### PR DESCRIPTION
The recent change https://github.com/facebook/jsx/pull/78 allowed JSXText nodes to be used as a child in JSXElement but did not define the JSXText node. This commits adds a definition for JXText.

We might want to define exactly what is the difference between the property `raw` and `value` or leave it up to parsers to decided. I believe currently esprima and flow convert CRLF line ending for the `value` property but leave the text as is in the `raw` property.