### PR TITLE
Fix "a" -> "an" in "a XML-like syntax"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DRAFT: JSX Specification
 ========================
 
-JSX is a XML-like syntax extension to ECMAScript without any defined semantics. It's NOT intended to be implemented by engines or browsers. __It's NOT a proposal to incorporate JSX into the ECMAScript spec itself.__ It's intended to be used by various preprocessors (transpilers) to transform these tokens into standard ECMAScript.
+JSX is an XML-like syntax extension to ECMAScript without any defined semantics. It's NOT intended to be implemented by engines or browsers. __It's NOT a proposal to incorporate JSX into the ECMAScript spec itself.__ It's intended to be used by various preprocessors (transpilers) to transform these tokens into standard ECMAScript.
 
 ```
 // Using JSX to express UI components.


### PR DESCRIPTION
Should read "an XML-like syntax".