### PR TITLE
Update copyright, make commas consistent, and fix broken links

### DIFF
--- a/AST.md
+++ b/AST.md
@@ -10,7 +10,7 @@ __JSX Identifier subtype__
 
 ```js
 interface JSXIdentifier <: Identifier {
-    type: "JSXIdentifier";
+    type: "JSXIdentifier",
 }
 ```
 
@@ -20,9 +20,9 @@ Property-like namespace syntax (tag names only):
 
 ```js
 interface JSXMemberExpression <: Expression {
-    type: "JSXMemberExpression";
+    type: "JSXMemberExpression",
     object: JSXMemberExpression | JSXIdentifier,
-    property: JSXIdentifier
+    property: JSXIdentifier,
 }
 ```
 
@@ -30,9 +30,9 @@ XML-based namespace syntax:
 
 ```js
 interface JSXNamespacedName <: Expression {
-    type: "JSXNamespacedName";
+    type: "JSXNamespacedName",
     namespace: JSXIdentifier,
-    name: JSXIdentifier
+    name: JSXIdentifier,
 }
 ```
 
@@ -43,7 +43,7 @@ JSX adds empty "expression" type in order to allow comments in JSX text:
 
 ```js
 interface JSXEmptyExpression <: Node {
-    type: "JSXEmptyExpression"
+    type: "JSXEmptyExpression",
 }
 ```
 
@@ -52,7 +52,7 @@ Any expression used as attribute value or inside JSX text should is wrapped into
 ```js
 interface JSXExpressionContainer <: Node {
     type: "JSXExpressionContainer",
-    expression: Expression | JSXEmptyExpression;
+    expression: Expression | JSXEmptyExpression,
 }
 ```
 
@@ -61,7 +61,7 @@ A JSX element uses a special form of an expression container for an iterator chi
 ```js
 interface JSXSpreadChild <: Node {
     type: "JSXSpreadChild",
-    expression: Expression
+    expression: Expression,
 }
 ```
 
@@ -72,17 +72,17 @@ Any JSX element is bounded by tags &mdash; either self-closing or both opening a
 
 ```js
 interface JSXBoundaryElement <: Node {
-    name: JSXIdentifier | JSXMemberExpression | JSXNamespacedName;
+    name: JSXIdentifier | JSXMemberExpression | JSXNamespacedName,
 }
 
 interface JSXOpeningElement <: JSXBoundaryElement {
     type: "JSXOpeningElement",
     attributes: [ JSXAttribute | JSXSpreadAttribute ],
-    selfClosing: boolean;
+    selfClosing: boolean,
 }
 
 interface JSXClosingElement <: JSXBoundaryElement {
-    type: "JSXClosingElement"
+    type: "JSXClosingElement",
 }
 ```
 
@@ -95,18 +95,18 @@ Opening element ("tag") may contain attributes:
 interface JSXAttribute <: Node {
     type: "JSXAttribute",
     name: JSXIdentifier | JSXNamespacedName,
-    value: Literal | JSXExpressionContainer | JSXElement | null
+    value: Literal | JSXExpressionContainer | JSXElement | null,
 }
 
 // This is already used by ES6 parsers, but not included
 // in Mozilla's spec yet.
 interface SpreadElement <: Node {
-    type: "SpreadElement";
-    argument: Expression;
+    type: "SpreadElement",
+    argument: Expression,
 }
 
 interface JSXSpreadAttribute <: SpreadElement {
-    type: "JSXSpreadAttribute";
+    type: "JSXSpreadAttribute",
 }
 ```
 
@@ -117,9 +117,9 @@ JSX Text node stores a string literal found in JSX element children.
 
 ```js
 interface JSXText <: Node {
-  type: "JSXText"
+  type: "JSXText",
   value: string,
-  raw: string
+  raw: string,
 }
 ```
 
@@ -133,7 +133,7 @@ interface JSXElement <: Expression {
     type: "JSXElement",
     openingElement: JSXOpeningElement,
     children: [ JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement ],
-    closingElement: JSXClosingElement | null
+    closingElement: JSXClosingElement | null,
 }
 ```
 
@@ -151,7 +151,7 @@ Tools that work with JSX AST
 License
 -------
 
-Copyright (c) 2014, Facebook, Inc.
+Copyright (c) 2014 - present, Facebook, Inc.
 All rights reserved.
 
 This work is licensed under a [Creative Commons Attribution 4.0

--- a/AST.md
+++ b/AST.md
@@ -10,7 +10,7 @@ __JSX Identifier subtype__
 
 ```js
 interface JSXIdentifier <: Identifier {
-    type: "JSXIdentifier",
+    type: "JSXIdentifier";
 }
 ```
 
@@ -20,9 +20,9 @@ Property-like namespace syntax (tag names only):
 
 ```js
 interface JSXMemberExpression <: Expression {
-    type: "JSXMemberExpression",
-    object: JSXMemberExpression | JSXIdentifier,
-    property: JSXIdentifier,
+    type: "JSXMemberExpression";
+    object: JSXMemberExpression | JSXIdentifier;
+    property: JSXIdentifier;
 }
 ```
 
@@ -30,9 +30,9 @@ XML-based namespace syntax:
 
 ```js
 interface JSXNamespacedName <: Expression {
-    type: "JSXNamespacedName",
-    namespace: JSXIdentifier,
-    name: JSXIdentifier,
+    type: "JSXNamespacedName";
+    namespace: JSXIdentifier;
+    name: JSXIdentifier;
 }
 ```
 
@@ -43,7 +43,7 @@ JSX adds empty "expression" type in order to allow comments in JSX text:
 
 ```js
 interface JSXEmptyExpression <: Node {
-    type: "JSXEmptyExpression",
+    type: "JSXEmptyExpression";
 }
 ```
 
@@ -51,8 +51,8 @@ Any expression used as attribute value or inside JSX text should is wrapped into
 
 ```js
 interface JSXExpressionContainer <: Node {
-    type: "JSXExpressionContainer",
-    expression: Expression | JSXEmptyExpression,
+    type: "JSXExpressionContainer";
+    expression: Expression | JSXEmptyExpression;
 }
 ```
 
@@ -60,8 +60,8 @@ A JSX element uses a special form of an expression container for an iterator chi
 
 ```js
 interface JSXSpreadChild <: Node {
-    type: "JSXSpreadChild",
-    expression: Expression,
+    type: "JSXSpreadChild";
+    expression: Expression;
 }
 ```
 
@@ -72,17 +72,17 @@ Any JSX element is bounded by tags &mdash; either self-closing or both opening a
 
 ```js
 interface JSXBoundaryElement <: Node {
-    name: JSXIdentifier | JSXMemberExpression | JSXNamespacedName,
+    name: JSXIdentifier | JSXMemberExpression | JSXNamespacedName;
 }
 
 interface JSXOpeningElement <: JSXBoundaryElement {
-    type: "JSXOpeningElement",
-    attributes: [ JSXAttribute | JSXSpreadAttribute ],
-    selfClosing: boolean,
+    type: "JSXOpeningElement";
+    attributes: [ JSXAttribute | JSXSpreadAttribute ];
+    selfClosing: boolean;
 }
 
 interface JSXClosingElement <: JSXBoundaryElement {
-    type: "JSXClosingElement",
+    type: "JSXClosingElement";
 }
 ```
 
@@ -93,20 +93,20 @@ Opening element ("tag") may contain attributes:
 
 ```js
 interface JSXAttribute <: Node {
-    type: "JSXAttribute",
-    name: JSXIdentifier | JSXNamespacedName,
-    value: Literal | JSXExpressionContainer | JSXElement | null,
+    type: "JSXAttribute";
+    name: JSXIdentifier | JSXNamespacedName;
+    value: Literal | JSXExpressionContainer | JSXElement | null;
 }
 
 // This is already used by ES6 parsers, but not included
 // in Mozilla's spec yet.
 interface SpreadElement <: Node {
-    type: "SpreadElement",
-    argument: Expression,
+    type: "SpreadElement";
+    argument: Expression;
 }
 
 interface JSXSpreadAttribute <: SpreadElement {
-    type: "JSXSpreadAttribute",
+    type: "JSXSpreadAttribute";
 }
 ```
 
@@ -117,9 +117,9 @@ JSX Text node stores a string literal found in JSX element children.
 
 ```js
 interface JSXText <: Node {
-  type: "JSXText",
-  value: string,
-  raw: string,
+  type: "JSXText";
+  value: string;
+  raw: string;
 }
 ```
 
@@ -130,10 +130,10 @@ Finally, JSX element itself consists of opening element, list of children and op
 
 ```js
 interface JSXElement <: Expression {
-    type: "JSXElement",
-    openingElement: JSXOpeningElement,
-    children: [ JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement ],
-    closingElement: JSXClosingElement | null,
+    type: "JSXElement";
+    openingElement: JSXOpeningElement;
+    children: [ JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement ];
+    closingElement: JSXClosingElement | null;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This specification does not attempt to comply with any XML or HTML specification
 Syntax
 ------
 
-_JSX extends the PrimaryExpression in the [ECMAScript 6th Edition (ECMA-262)](http://people.mozilla.org/~jorendorff/es6-draft.html) grammar:_
+_JSX extends the PrimaryExpression in the [ECMAScript 6th Edition (ECMA-262)](https://www.ecma-international.org/ecma-262/8.0/index.html) grammar:_
 
 PrimaryExpression :
 
@@ -178,7 +178,7 @@ NOTE: A conforming transpiler may choose to use a subset of the JSX syntax.
 Why not Template Literals?
 --------------------------
 
-[ECMAScript 6th Edition (ECMA-262)](http://people.mozilla.org/~jorendorff/es6-draft.html) introduces template literals which are intended to be used for embedding DSL in ECMAScript. Why not just use that instead of inventing a syntax that's not part of ECMAScript?
+[ECMAScript 6th Edition (ECMA-262)](https://www.ecma-international.org/ecma-262/8.0/index.html) introduces template literals which are intended to be used for embedding DSL in ECMAScript. Why not just use that instead of inventing a syntax that's not part of ECMAScript?
 
 Template literals work well for long embedded DSLs. Unfortunately the syntax noise is substantial when you exit in and out of embedded arbitrary ECMAScript expressions with identifiers in scope.
 
@@ -247,7 +247,7 @@ The JSX syntax is similar to the [E4X Specification (ECMA-357)](http://www.ecma-
 License
 -------
 
-Copyright (c) 2014, Facebook, Inc.
+Copyright (c) 2014 - present, Facebook, Inc.
 All rights reserved.
 
 This work is licensed under a [Creative Commons Attribution 4.0


### PR DESCRIPTION
This PR simply tidies up the documentation a bit. 

- broken links (https://github.com/facebook/jsx/issues/91)
- there was inconsistent usage of commas and semicolons, so I replaced all instances with commas