### PR TITLE
Add proposed fragment changes

### DIFF
--- a/AST.md
+++ b/AST.md
@@ -126,7 +126,7 @@ interface JSXText <: Node {
 JSX Element
 -----------
 
-JSX element itself consists of opening element, list of children and optional closing element:
+JSX element consists of opening element, list of children and optional closing element:
 
 ```js
 interface JSXElement <: Expression {
@@ -140,7 +140,7 @@ interface JSXElement <: Expression {
 JSX Fragment
 ------------
 
-JSX fragment itself consists of an opening fragment, list of children, and closing fragment:
+JSX fragment consists of an opening fragment, list of children, and closing fragment:
 
 ```js
 interface JSXFragment <: Expression {

--- a/AST.md
+++ b/AST.md
@@ -73,13 +73,12 @@ Any JSX element is bounded by tags &mdash; either self-closing or both opening a
 ```js
 interface JSXBoundaryElement <: Node {
     name: JSXIdentifier | JSXMemberExpression | JSXNamespacedName;
-    isFragment: boolean;
 }
 
 interface JSXOpeningElement <: JSXBoundaryElement {
     type: "JSXOpeningElement",
     attributes: [ JSXAttribute | JSXSpreadAttribute ],
-    selfClosing: boolean; // if this is true, isFragment must be false, and vice-versa
+    selfClosing: boolean;
 }
 
 interface JSXClosingElement <: JSXBoundaryElement {
@@ -127,15 +126,40 @@ interface JSXText <: Node {
 JSX Element
 -----------
 
-Finally, JSX element itself consists of opening element, list of children and optional closing element:
+JSX element itself consists of opening element, list of children and optional closing element:
 
 ```js
 interface JSXElement <: Expression {
     type: "JSXElement",
     openingElement: JSXOpeningElement,
-    children: [ JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement ],
-    closingElement: JSXClosingElement | null,
-    isFragment: boolean;
+    children: [ JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement | JSXFragment ];
+    closingElement: JSXClosingElement | null;
+}
+```
+
+JSX Fragment
+------------
+
+JSX fragment itself consists of an opening fragment, list of children, and closing fragment:
+
+```js
+interface JSXFragment <: Expression {
+    type: "JSXFragment";
+    openingFragment: JSXOpeningFragment;
+    children: [ JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement | JSXFragment ];
+    closingFragment: JSXClosingFragment;
+}
+```
+
+```js
+interface JSXOpeningFragment <: Node {
+    type: "JSXOpeningFragment";
+}
+```
+
+```js
+interface JSXClosingFragment <: Node {
+    type: "JSXClosingFragment";
 }
 ```
 

--- a/AST.md
+++ b/AST.md
@@ -73,12 +73,13 @@ Any JSX element is bounded by tags &mdash; either self-closing or both opening a
 ```js
 interface JSXBoundaryElement <: Node {
     name: JSXIdentifier | JSXMemberExpression | JSXNamespacedName;
+    isFragment: boolean;
 }
 
 interface JSXOpeningElement <: JSXBoundaryElement {
     type: "JSXOpeningElement",
     attributes: [ JSXAttribute | JSXSpreadAttribute ],
-    selfClosing: boolean;
+    selfClosing: boolean; // if this is true, isFragment must be false, and vice-versa
 }
 
 interface JSXClosingElement <: JSXBoundaryElement {
@@ -133,7 +134,8 @@ interface JSXElement <: Expression {
     type: "JSXElement",
     openingElement: JSXOpeningElement,
     children: [ JSXText | JSXExpressionContainer | JSXSpreadChild | JSXElement ],
-    closingElement: JSXClosingElement | null
+    closingElement: JSXClosingElement | null,
+    isFragment: boolean;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,14 +63,7 @@ JSXClosingElement :
 
 JSXFragment :
 
-- JSXOpeningFragment JSXChildren<sub>opt</sub> JSXClosingFragment
-
-JSXOpeningFragment :
-
-- `<>`
-
-JSXClosingFragment :
-- `</>`
+- <> JSXChildren<sub>opt</sub> </>
 
 JSXElementName :
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ JSXElement : 
 JSXSelfClosingElement :
 
 - `<` JSXElementName JSXAttributes<sub>opt</sub> `/` `>`
+  (isFragment cannot be true if selfClosing)
 
 JSXOpeningElement :
 
 - `<` JSXElementName JSXAttributes<sub>opt</sub> `>`
+  (no JSXAttributes allowed if isFragment is true)
 
 JSXClosingElement :
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ JSXClosingElement :
 
 JSXFragment :
 
-- <> JSXChildren<sub>opt</sub> </>
+- `<` `>` JSXChildren<sub>opt</sub> `<` `/` `>`
 
 JSXElementName :
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ _JSX extends the PrimaryExpression in the [ECMAScript 6th Edition (ECMA-262)](ht
 PrimaryExpression :
 
 - JSXElement
+- JSXFragment
 
 __Elements__
 
@@ -51,16 +52,25 @@ JSXElement : 
 JSXSelfClosingElement :
 
 - `<` JSXElementName JSXAttributes<sub>opt</sub> `/` `>`
-  (isFragment cannot be true if selfClosing)
 
 JSXOpeningElement :
 
 - `<` JSXElementName JSXAttributes<sub>opt</sub> `>`
-  (no JSXAttributes allowed if isFragment is true)
 
 JSXClosingElement :
 
 - `<` `/` JSXElementName `>`
+
+JSXFragment :
+
+- JSXOpeningFragment JSXChildren<sub>opt</sub> JSXClosingFragment
+
+JSXOpeningFragment :
+
+- `<>`
+
+JSXClosingFragment :
+- `</>`
 
 JSXElementName :
 


### PR DESCRIPTION
This is the JSX spec change for supporting `<></>` fragment syntax in JSX. One of the tougher design decisions on this spec was whether to go with a new node type for fragments (e.g. `JSXFragment`, or re-use the existing `JSXElement` node with an additional `isFragment` field. I opted for the latter because:

- a fragment has very similar behavior to a `JSXElement` in terms of the AST (e.g. it contains children, openingElement, and closingElement)
- the pattern of using a flag has already been adopted in the spec (e.g. selfClosing)
- this has the lowest amount of friction when integrating with the current ecosystem

To illustrate the last point, I've written forks of [babel](https://github.com/clemmy/babel), [babylon](https://github.com/clemmy/babylon), and [eslint-plugin-react](https://github.com/clemmy/eslint-plugin-react) to prototype, and it turned out to have very few LOC.

Some example scenarios:
`< ></> // success`

`<></> // success`

`< attrib></> // fail`

`<>hi</> // success`

`<><span>hi</span><div>bye</div></> // success`

`<></something> // fail`

**UPDATE**
Spec has been updated to introduce new node type `JSXFragment` instead of re-using `JSXElement`.

