### PR TITLE
Update spec for putting JSXFragment inside attributes

### DIFF
--- a/AST.md
+++ b/AST.md
@@ -95,7 +95,7 @@ Opening element ("tag") may contain attributes:
 interface JSXAttribute <: Node {
     type: "JSXAttribute";
     name: JSXIdentifier | JSXNamespacedName;
-    value: Literal | JSXExpressionContainer | JSXElement | null;
+    value: Literal | JSXExpressionContainer | JSXElement | JSXFragment | null;
 }
 
 // This is already used by ES6 parsers, but not included

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ JSXAttributeValue : 
 - `'` JSXSingleStringCharacters<sub>opt</sub> `'`
 - `{` AssignmentExpression `}`
 - JSXElement
+- JSXFragment
 
 JSXDoubleStringCharacters : 
 


### PR DESCRIPTION
I think this is desired behavior and something that was overlooked in https://github.com/facebook/jsx/pull/93 - the idea is to allow fragments to be a part of JSX attributes. For example,`<MyComponent attrib={<></>} />`.