### PR TITLE
Fix: Add JSXFragment as a possible child of JSXChild

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ JSXChild :
 
 - JSXText
 - JSXElement
+- JSXFragment
 - `{` JSXChildExpression<sub>opt</sub> `}`
 
 JSXText :


### PR DESCRIPTION
Also overlooked in https://github.com/facebook/jsx/pull/93. Thanks @uniqueiniquity for pointing it out.