### PR TITLE
RFC: React Expressions with Implicit Do-Generator Semantics

### DIFF
--- a/AST.md
+++ b/AST.md
@@ -44,8 +44,8 @@ The expression container node contains statements with the same grammar as a gen
 ```js
 interface JSXExpressionContainer <: Node {
     type: "JSXExpressionContainer";
-    body: Expression | JSXEmptyExpression | JSXStatementList;
-    expression: boolean;
+    expression: Expression | JSXEmptyExpression | JSXStatementList;
+    isExpression: boolean;
 }
 ```
 

--- a/AST.md
+++ b/AST.md
@@ -39,20 +39,13 @@ interface JSXNamespacedName <: Expression {
 JSX Expression Container
 ------------------------
 
-JSX adds empty "expression" type in order to allow comments in JSX text:
+The expression container node contains statements with the same grammar as a generator body. Also it has a flag to indicate if a yield is present in the body. Any expression used as attribute value or inside JSX text should is wrapped into expression container:
 
 ```js
-interface JSXEmptyExpression <: Node {
-    type: "JSXEmptyExpression";
-}
-```
-
-Any expression used as attribute value or inside JSX text should is wrapped into expression container:
-
-```js
-interface JSXExpressionContainer <: Node {
+interface JSXExpressionContainer <: Expression {
     type: "JSXExpressionContainer";
-    expression: Expression | JSXEmptyExpression;
+    statements: [ Statement | Declaration ];
+    hasYield: boolean;
 }
 ```
 

--- a/AST.md
+++ b/AST.md
@@ -39,13 +39,21 @@ interface JSXNamespacedName <: Expression {
 JSX Expression Container
 ------------------------
 
-The expression container node contains statements with the same grammar as a generator body. Also it has a flag to indicate if a yield is present in the body. Any expression used as attribute value or inside JSX text should is wrapped into expression container:
+The expression container node contains statements with the same grammar as a generator body. Also it has a flag to indicate whether it is an expression. Any expression used as attribute value or inside JSX text should be wrapped by expression container:
 
 ```js
-interface JSXExpressionContainer <: Expression {
+interface JSXExpressionContainer <: Node {
     type: "JSXExpressionContainer";
-    statements: [ Statement | Declaration ];
-    hasYield: boolean;
+    body: Expression | JSXEmptyExpression | JSXStatementList;
+    expression: boolean;
+}
+```
+
+```js
+interface JSXStatementList <: Node {
+  type: "JSXStatementList";
+  body: [ Statement ];
+  generator: boolean;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ JSXAttributes : 
 
 JSXSpreadAttribute :
 
-- `{` `...` JSXGeneratorExpression `}`
+- `{` `...` AssignmentExpression `}`
 
 JSXAttribute : 
 
@@ -121,8 +121,12 @@ JSXAttributeValue : 
 
 JSXGeneratorExpression :
 
-- [lookahead &#8712; { `{` }] ObjectLiteral
-- StatementList<sub>[+Yield]</sub>
+- ObjectLiteral
+- FunctionExpression
+- ClassExpression
+- GeneratorExpression
+- AsyncFunctionExpression
+- [lookahead &#8713; { `{` }] StatementList<sub>[+Yield]</sub>
 
 JSXDoubleStringCharacters : 
 
@@ -164,7 +168,7 @@ JSXTextCharacter :
 JSXChildExpression :
 
 - JSXGeneratorExpression
-- `...` JSXGeneratorExpression
+- `...` AssignmentExpression
 
 __Whitespace and Comments__
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ PrimaryExpression :
 
 - JSXElement
 - JSXFragment
+- JSXGeneratorExpression
 
 __Elements__
 
@@ -95,7 +96,7 @@ JSXAttributes : 
 
 JSXSpreadAttribute :
 
-- `{` `...` AssignmentExpression `}`
+- `{` `...` JSXGeneratorExpression `}`
 
 JSXAttribute : 
 
@@ -114,9 +115,14 @@ JSXAttributeValue : 
 
 - `"` JSXDoubleStringCharacters<sub>opt</sub> `"`
 - `'` JSXSingleStringCharacters<sub>opt</sub> `'`
-- `{` AssignmentExpression `}`
+- `{` JSXGeneratorExpression `}`
 - JSXElement
 - JSXFragment
+
+JSXGeneratorExpression :
+
+- [lookahead &#8712; { `{` }] ObjectLiteral
+- StatementList<sub>[+Yield]</sub>
 
 JSXDoubleStringCharacters : 
 
@@ -157,8 +163,8 @@ JSXTextCharacter :
 
 JSXChildExpression :
 
-- AssignmentExpression
-- `...` AssignmentExpression
+- JSXGeneratorExpression
+- `...` JSXGeneratorExpression
 
 __Whitespace and Comments__
 


### PR DESCRIPTION
## RFC: React Expressions with Implicit Do-Generator Semantics

### Background

A highly requested feature of React seems to be a nicer way to loop and write conditionals inside JSX. For example this StackOverflow [question](https://stackoverflow.com/questions/22876978/loop-inside-react-jsx) about loops in JSX has over 300k views, and there are popular libraries such as [jsx-control-statements](https://github.com/AlexGilleran/jsx-control-statements) written in order to address this fundamental feature of a templating language. This fostered discussions such as https://github.com/facebook/jsx/issues/39, https://github.com/facebook/jsx/issues/88, and https://github.com/reactjs/react-future/issues/35, suggesting syntax in order to allow for similar capabilities in JSX. With the new JSX semantics, you'd be able to do something like this:

```
<div>{ for (let item of items) yield item; }</div>
// loops!
```

```
<div className={ if (foo) 'bar'; } />
// conditionals!
```

while keeping the old behavior as well.

```
<div>{ items.map(i => <li key={i.key} />) }</div> // expression

<div style={{ position: 'absolute' }} /> // object literal

// these still work!
```

### Proposal

The proposal is to use a combination of implicit do expression [semantics](https://babeljs.io/docs/plugins/transform-do-expressions/) as well as implicit generator expression [semantics](https://github.com/sebmarkbage/ecmascript-generator-expression) to fulfill a wide range of use cases. (By implicit, I mean omitting the `do` in do-expressions and the `*` in generator expressions). We'll extend the grammar for the `JSXExpression` block, to accept a list of statements. These statements are what you would usually find inside a `Block`, but it also allows the `yield` keyword. Additionally, there will be the following criteria:

1. If it starts with `{`, then that is an `ObjectLiteral`, not a `BlockStatement` (Ignoring leading comments and open parenthesis). Similarly, if it starts with a (async) function expression, class expression, or generator expression, then it is of that following type.

2. `continue` is not allowed at the top scope. They are allowed inside a nested block as long as they don't reference at a higher scope level than their own.

3. `return` is not allowed except inside nested functions.

This allows for code like the following:

```
<div>{ for (let item of items) yield item; }</div>
```

The semantics for the evaluation of the code in-between the braces `{...}` are as follows:

```
// if yield keyword is used inside JSXExpression
$ReactJSXExpression((function*() { return do { ... } })())

function $ReactJSXExpression(generator) {
  let yields = [];
  let next;
  while (next = generator.next()) {
    if (next.done) {
      break;
    } else {
      yields.push(next.value);
    }
  }
  return yields;
}
// if no yields inside the JSXExpression
$ReactJSXExpression(do { ... })

// adapted from https://github.com/facebook/jsx/issues/88#issuecomment-339022316
```

### Test cases

https://gist.github.com/clemmy/f0de896e4853172d88f664ab23c517d9

### Alternative Considerations

@sebmarkbage and I converged on the proposal I outlined above after a lot of discussion. At first glance, it probably looks a bit weird since the behavior of the same syntax differs depending on whether a yield is present or not, but hey, that's better than one of our thoughts to make that behavior dynamic based on runtime. 🙂 Here are some of the alternative proposals we considered:

#### Always using generator expression semantics:
##### Cons:
This would be a breaking change with current JSX since yields will always be returned as an array; the following wouldn't be valid anymore:
```
<div style={{ position: 'absolute' }} /> // object literal
```
In order to fix this, we use a modified generator expression semantics approach:

#### Always using generator expressions semantics # 2

```
$ReactJSXExpression((function*() { return do { ... } })())

function $ReactJSXExpression(generator) {
  let yields = [];
  let completion = undefined;
  let next;
  while (next = generator.next()) {
    if (next.done) {
      completion = next.value;
      break;
    } else {
      yields.push(next.value);
    }
  }
  if (yields.length > 0) {
    return yields;
  } else {
     return completion;
  }
}
// adapted from https://github.com/facebook/jsx/issues/88#issuecomment-339022316
```
##### Cons:
The behavior is dictated by the runtime (e.g. whether we return `completion` or `yields` is based on the runtime evaluation of the length of `yields`).

#### Do Expression by default and explicit generator expression syntax
For example, we can use `[ ... ]` to indicate that it's a generator expression. This allows the following code, which is actually quite nice:

```
<div>[ for (let item of items) yield <Item key={item.id} item={item} />; ]</div>
```

##### Cons:
This would break existing JSX where an opening `[` is a part of the text inside `JSXChildren`.

#### Do Expression by default and explicit generator expression syntax # 2
Similar to the above `[ ... ]`, but we use a star instead (`*{ ... }`). It was hard to decide between this one and the main proposal.

### Related Links

- https://web.archive.org/web/20161123223109/http://wiki.ecmascript.org:80/doku.php?id=strawman:block_vs_object_literal
- https://github.com/facebook/jsx/issues/39
- https://github.com/facebook/jsx/issues/88
- https://github.com/reactjs/react-future/issues/35
- http://web.archive.org/web/20170116170648/http://wiki.ecmascript.org/doku.php?id=strawman%3Ado_expressions
- https://github.com/sebmarkbage/ecmascript-generator-expression