### PR TITLE
RFC: React Expressions with Explicit Do-Generator Semantics

### DIFF
--- a/AST.md
+++ b/AST.md
@@ -47,12 +47,22 @@ interface JSXEmptyExpression <: Node {
 }
 ```
 
-Any expression used as attribute value or inside JSX text should is wrapped into expression container:
+The expression container node contains statements with the same grammar as a generator body. Also it has a flag to indicate whether it is an expression. Any expression used as attribute value or inside JSX text should is wrapped into expression container:
 
 ```js
 interface JSXExpressionContainer <: Node {
     type: "JSXExpressionContainer";
-    expression: Expression | JSXEmptyExpression;
+    expression: Expression | JSXEmptyExpression | JSXBlockStatement;
+    isExpression: boolean;
+}
+```
+
+From `BlockStatement`, this inherits `body: [ Statement ];`.
+
+```js
+interface JSXBlockStatement <: BlockStatement {
+  type: "JSXStatementList";
+  generator: boolean;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ PrimaryExpression :
 
 - JSXElement
 - JSXFragment
+- JSXGeneratorExpressionContainer
 
 __Elements__
 
@@ -115,8 +116,20 @@ JSXAttributeValue : 
 - `"` JSXDoubleStringCharacters<sub>opt</sub> `"`
 - `'` JSXSingleStringCharacters<sub>opt</sub> `'`
 - `{` AssignmentExpression `}`
+- JSXGeneratorExpressionContainer
 - JSXElement
 - JSXFragment
+
+JSXGeneratorExpressionContainer :
+- `*` `{` JSXGeneratorExpression<sub>opt</sub> `}`
+
+JSXGeneratorExpression :
+- ObjectLiteral
+- FunctionExpression
+- ClassExpression
+- GeneratorExpression
+- AsyncFunctionExpression
+- FunctionBody<sub>[+Yield, ~Await, ~Return]</sub>
 
 JSXDoubleStringCharacters : 
 
@@ -145,6 +158,7 @@ JSXChild :
 - JSXText
 - JSXElement
 - JSXFragment
+- JSXGeneratorExpressionContainer
 - `{` JSXChildExpression<sub>opt</sub> `}`
 
 JSXText :


### PR DESCRIPTION
## RFC: React Expressions with Explicit Do-Generator Semantics

### Background

For more background on this proposal, please refer to https://github.com/facebook/jsx/pull/98.
In that thread, there was a lot of backlash for the implicit nature of the do-generator by unifying it with the current `{}` JSX expression syntax. This proposal makes it explicit by using the `*{...}` syntax for do generator expressions. So all the old goodies will be kept:

```
<div>{ items.map(i => <li key={i.key} />) }</div> // expression

<div style={{ position: 'absolute' }} /> // object literal

// these still work!
```

But more adventurous users will be able to use the following for do-generator expressions:

```
<div>*{ for (let item of items) yield item; }</div>
// loops!
```

```
<div className=*{ if (foo) 'bar'; } />
// conditionals!
```

Note that the plan is to get this into the ECMAScript specification eventually, if this turns out to be successful in JSX (https://github.com/sebmarkbage/ecmascript-generator-expression). If it's a failure, however, the refactor back to old JSX expressions should be pretty easy, so it allows for some experimentation with low risk.

### Proposal

We'll extend the grammar for the `JSXExpression` block, to accept a list of statements. These statements are what you would usually find inside a `Block`, but it also allows the `yield` keyword. Additionally, there will be the following criteria:

1. If it starts with `{`, then that is an `ObjectLiteral`, not a `BlockStatement` (Ignoring leading comments and open parenthesis). Similarly, if it starts with a (async) function expression, class expression, or generator expression, then it is of that following type.

2. `continue` is not allowed at the top scope. They are allowed inside a nested block as long as they don't reference at a higher scope level than their own.

3. `return` is not allowed except inside nested functions.

This allows for code like the following:

```
<div>*{ for (let item of items) yield item; }</div>
```

The semantics for the evaluation of the code in-between the braces `*{...}` are as follows:

```
// if yield keyword is used inside JSXExpression
$ReactJSXExpression((function*() { return do { ... } })())

function $ReactJSXExpression(generator) {
  let yields = [];
  let next;
  while (next = generator.next()) {
    if (next.done) {
      break;
    } else {
      yields.push(next.value);
    }
  }
  return yields;
}
// if no yields inside the JSXExpression
$ReactJSXExpression(do { ... })

// adapted from https://github.com/facebook/jsx/issues/88#issuecomment-339022316
```

### Test cases

https://gist.github.com/clemmy/ba676e384a050790b94f99698033306c

### Caveats

Strings in `JSXText` with a `*` before a `JSXExpression` will be parsed as a `JSXGeneratorExpression`.

```
<div>
  This is a paragraph* with some asterisk.
  *{explanation}
</div>
```