### PR TITLE
Remove <br/> tag that renders in html page

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ __Elements__
 JSXElement : 
 
 - JSXSelfClosingElement 
-- JSXOpeningElement JSXChildren<sub>opt</sub> JSXClosingElement<br />
+- JSXOpeningElement JSXChildren<sub>opt</sub> JSXClosingElement  
   (names of JSXOpeningElement and JSXClosingElement should match)
 
 JSXSelfClosingElement :


### PR DESCRIPTION
You can just use two spaces at the end of a line in order to force a line break