### PR TITLE
Correct acorn-jsx description - plugin not a fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ _JSX uses the same punctuators and braces as ECMAScript. WhiteSpace, LineTermina
 Parser Implementations
 ----------------------
 
-- [acorn-jsx](https://github.com/RReverser/acorn-jsx): A fork of acorn.
+- [acorn-jsx](https://github.com/RReverser/acorn-jsx): A plugin for acorn.
 - [esprima-fb](https://github.com/facebook/esprima): A fork of esprima.
 - [jsx-reader](https://github.com/jlongster/jsx-reader): A sweet.js macro.
 


### PR DESCRIPTION
While it may have been accurate some time ago, acorn-jsx is no longer a fork of acorn, but rather a plugin for acorn. I thought I'd correct this issue by submitting a small change.