### PR TITLE
JSX Proposal: ES6-like property value shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ __Elements__
 JSXElement : 
 
 - JSXSelfClosingElement 
-- JSXOpeningElement JSXChildren<sub>opt</sub> JSXClosingElement  
+- JSXOpeningElement JSXChildren<sub>opt</sub> JSXClosingElement
   (names of JSXOpeningElement and JSXClosingElement should match)
 
 JSXSelfClosingElement :
@@ -90,12 +90,8 @@ __Attributes__
 
 JSXAttributes : 
 
-- JSXSpreadAttribute JSXAttributes<sub>opt</sub>
+- ObjectExpression JSXAttributes<sub>opt</sub>
 - JSXAttribute JSXAttributes<sub>opt</sub>
-
-JSXSpreadAttribute :
-
-- `{` `...` AssignmentExpression `}`
 
 JSXAttribute : 
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,12 @@ __Attributes__
 
 JSXAttributes : 
 
-- ObjectExpression JSXAttributes<sub>opt</sub>
+- JSXSpreadAttribute JSXAttributes<sub>opt</sub>
 - JSXAttribute JSXAttributes<sub>opt</sub>
+
+JSXSpreadAttribute :
+
+- `{` `...` AssignmentExpression `}`
 
 JSXAttribute : 
 

--- a/README.md
+++ b/README.md
@@ -88,14 +88,19 @@ JSXMemberExpression :
 
 __Attributes__
 
-JSXAttributes : 
+JSXAttributes :
 
-- JSXSpreadAttribute JSXAttributes<sub>opt</sub>
+- `{` JSXAttributesShorthand `}` JSXAttributes<sub>opt</sub>
 - JSXAttribute JSXAttributes<sub>opt</sub>
 
-JSXSpreadAttribute :
+JSXAttributesShorthand :
 
-- `{` `...` AssignmentExpression `}`
+- JSXAttributeShorthand JSXAttributesShorthand<sub>opt</sub>
+
+JSXAttributeShorthand :
+
+- `...` AssignmentExpression `,`<sub>opt</sub>
+- Identifier `,`<sub>opt</sub>
 
 JSXAttribute : 
 


### PR DESCRIPTION
This discussion has happened in several repos now.

https://github.com/microsoft/TypeScript/issues/31797
https://github.com/facebook/jsx/issues/23
https://github.com/facebook/react/issues/2536

Currently the JSX syntax supports the following transformations. Using h for brevity.

```
<div title="hello" />
```  
```
 h(`div`, {title: 'hello'}) >
```

---

```
const title = 'foo';
<div title={title} />
```  
^ seems verbose
```
h(`div`, {title}) >
```

---

``` 
<input checked />
```
 Attribute on it's own always resolves to true (inspired from html)
 ``` 
h(`input`, {checked: true}) >
```

---

``` 
const props = {a: 1, b: 2, c: 3};
<Foo {...props} />
```
 JSX spread operator is awesome 🎉. It came before object spread and shorthand was finalized in ES spec. So we can understand why {....x} is strict. We can `<div {...{title}} />` though, which is ugly.
 ``` 
h(Foo, {...props}) >
```


 New Proposal: Use {Identifier} shorthand which would be a superset of JSXSpreadAttribute. 
===

Object shorthand and spread is now supported in every major js engine and browsers. It's common js lingo now.

``` 
const d = 4;
const props = {a: 1, b: 2, c: 3};
<input checked {...props, d} />
```
 ``` 
h(`input`, {checked: true, ...props, d} >
```

---
```
const x = 1;
const y = 2;
<div {x} {y} />
```  
```
h(`div`, {x, y}) >
```

---

The kind proposal is to upgrade JSX attribute spread syntax to also include {x} shorthand syntax that have been part of ES Spec and implemented in all major engines. It's a non breaking change since JSXAttributeSpread remains as is. 

The transform is simply merging multiple object expressions into a single object expression and send it as second argument to `jsxFactory(component: string | Component, attrs: {[attr]: any}, ...children)`. For a down transpile to ES5, use Object.assign as usual.

This would make writing JSX more expressive with less typing to do. The learning curve is minimal too since it's piggy-backing on the powerful ES object expression syntax.

As from the react documentation, they don't recommend using the normal attribute shorthand  https://reactjs.org/docs/jsx-in-depth.html#props-default-to-true

In their words `In general, we don’t recommend using this because it can be confused with the ES6 object shorthand {foo} which is short for {foo: foo} rather than {foo: true}. This behavior is just there so that it matches the behavior of HTML.`

This would remove some of that confusion and give an elegant ES6-like way to move foward without complicating jsx spec.

I'm hoping the 👨‍🚀 👩‍🚀 contributors and community are at-least open to the idea.