### PR TITLE
Add TemplateLiteral support to JSXAttribute.

### DIFF
--- a/AST.md
+++ b/AST.md
@@ -103,11 +103,6 @@ interface JSXSpreadAttribute <: SpreadElement {
 }
 ```
 
-References:
-
-1. [Literal](https://github.com/estree/estree/blob/master/es5.md#literal)
-2. [TemplateLiteral](https://github.com/estree/estree/blob/master/es2015.md#templateliteral)
-
 JSX Text
 --------
 
@@ -165,7 +160,7 @@ Tools that work with JSX AST
 ----------------------------
 
 * Parsers:
-  - [@babel/parser](https://github.com/babel/babel/tree/main/packages/babel-parser)
+  - [babylon](https://github.com/babel/babylon)
   - [flow-parser](https://www.npmjs.com/package/flow-parser)
   - [typescript](https://www.typescriptlang.org/docs/handbook/jsx.html)
   - [esprima](https://esprima.readthedocs.io/en/latest/syntactic-analysis.html#jsx-syntax-support)

--- a/AST.md
+++ b/AST.md
@@ -95,13 +95,18 @@ Opening element ("tag") may contain attributes:
 interface JSXAttribute <: Node {
     type: "JSXAttribute";
     name: JSXIdentifier | JSXNamespacedName;
-    value: Literal | JSXExpressionContainer | JSXElement | JSXFragment | null;
+    value: Literal | TemplateLiteral | JSXExpressionContainer | JSXElement | JSXFragment | null;
 }
 
 interface JSXSpreadAttribute <: SpreadElement {
     type: "JSXSpreadAttribute";
 }
 ```
+
+References:
+
+1. [Literal](https://github.com/estree/estree/blob/master/es5.md#literal)
+2. [TemplateLiteral](https://github.com/estree/estree/blob/master/es2015.md#templateliteral)
 
 JSX Text
 --------
@@ -160,7 +165,7 @@ Tools that work with JSX AST
 ----------------------------
 
 * Parsers:
-  - [babylon](https://github.com/babel/babylon)
+  - [@babel/parser](https://github.com/babel/packages/babel-parser)
   - [flow-parser](https://www.npmjs.com/package/flow-parser)
   - [typescript](https://www.typescriptlang.org/docs/handbook/jsx.html)
   - [esprima](https://esprima.readthedocs.io/en/latest/syntactic-analysis.html#jsx-syntax-support)

--- a/AST.md
+++ b/AST.md
@@ -165,7 +165,7 @@ Tools that work with JSX AST
 ----------------------------
 
 * Parsers:
-  - [@babel/parser](https://github.com/babel/packages/babel-parser)
+  - [@babel/parser](https://github.com/babel/babel/tree/main/packages/babel-parser)
   - [flow-parser](https://www.npmjs.com/package/flow-parser)
   - [typescript](https://www.typescriptlang.org/docs/handbook/jsx.html)
   - [esprima](https://esprima.readthedocs.io/en/latest/syntactic-analysis.html#jsx-syntax-support)

--- a/README.md
+++ b/README.md
@@ -127,13 +127,9 @@ JSXDoubleStringCharacter : 
 
 - SourceCharacter __but not `"`__
 
-> NOTE: The string value that is produced from these characters does *not* follow the [SV](https://tc39.es/ecma262/#sec-static-semantics-sv) procedure, but instead the rules defined in the [attribute value section](https://html.spec.whatwg.org/#attribute-value-(double-quoted)-state) of the HTML specification. Including the decoding of [character references](https://html.spec.whatwg.org/#character-references).
-
 JSXSingleStringCharacters : 
 
 - JSXSingleStringCharacter JSXSingleStringCharacters<sub>opt</sub>
-
-> NOTE: The string value that is produced from these characters does *not* follow the [SV](https://tc39.es/ecma262/#sec-static-semantics-sv) procedure, but instead the rules defined in the [attribute value section](https://html.spec.whatwg.org/#attribute-value-(single-quoted)-state) of the HTML specification. Including the decoding of [character references](https://html.spec.whatwg.org/#character-references).
 
 JSXSingleStringCharacter : 
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ JSXElementName :
 
 JSXIdentifier :
 
-- IdentifierStart
-- JSXIdentifier IdentifierPart
+- [IdentifierStart](https://tc39.es/ecma262/#prod-IdentifierStart)
+- JSXIdentifier [IdentifierPart](https://tc39.es/ecma262/#prod-IdentifierPart)
 - JSXIdentifier __NO WHITESPACE OR COMMENT__ `-`
 
 JSXNamespacedName :
@@ -95,7 +95,7 @@ JSXAttributes : 
 
 JSXSpreadAttribute :
 
-- `{` `...` AssignmentExpression `}`
+- `{` `...` [AssignmentExpression](https://tc39.es/ecma262/#prod-AssignmentExpression) `}`
 
 JSXAttribute : 
 
@@ -114,7 +114,8 @@ JSXAttributeValue : 
 
 - `"` JSXDoubleStringCharacters<sub>opt</sub> `"`
 - `'` JSXSingleStringCharacters<sub>opt</sub> `'`
-- `{` AssignmentExpression `}`
+- [TemplateLiteral](https://tc39.es/ecma262/#prod-Template)
+- `{` [AssignmentExpression](https://tc39.es/ecma262/#prod-AssignmentExpression) `}`
 - JSXElement
 - JSXFragment
 
@@ -126,13 +127,17 @@ JSXDoubleStringCharacter : 
 
 - SourceCharacter __but not `"`__
 
+> NOTE: The string value that is produced from these characters does *not* follow the [SV](https://tc39.es/ecma262/#sec-static-semantics-sv) procedure, but instead the rules defined in the [attribute value section](https://html.spec.whatwg.org/#attribute-value-(double-quoted)-state) of the HTML specification. Including the decoding of [character references](https://html.spec.whatwg.org/#character-references).
+
 JSXSingleStringCharacters : 
 
 - JSXSingleStringCharacter JSXSingleStringCharacters<sub>opt</sub>
 
+> NOTE: The string value that is produced from these characters does *not* follow the [SV](https://tc39.es/ecma262/#sec-static-semantics-sv) procedure, but instead the rules defined in the [attribute value section](https://html.spec.whatwg.org/#attribute-value-(single-quoted)-state) of the HTML specification. Including the decoding of [character references](https://html.spec.whatwg.org/#character-references).
+
 JSXSingleStringCharacter : 
 
-- SourceCharacter __but not `'`__
+- [SourceCharacter](https://tc39.es/ecma262/#prod-SourceCharacter) __but not `'`__
 
 __Children__
 
@@ -153,16 +158,16 @@ JSXText :
 
 JSXTextCharacter :
 
-- SourceCharacter __but not one of `{`, `<`, `>` or `}`__
+- [SourceCharacter](https://tc39.es/ecma262/#prod-SourceCharacter) __but not one of `{`, `<`, `>` or `}`__
 
 JSXChildExpression :
 
-- AssignmentExpression
-- `...` AssignmentExpression
+- [AssignmentExpression](https://tc39.es/ecma262/#prod-AssignmentExpression)
+- `...` [AssignmentExpression](https://tc39.es/ecma262/#prod-AssignmentExpression)
 
 __Whitespace and Comments__
 
-_JSX uses the same punctuators and braces as ECMAScript. WhiteSpace, LineTerminators and Comments are generally allowed between any punctuators._
+_JSX uses the same punctuators and braces as ECMAScript. [WhiteSpace](https://tc39.es/ecma262/#sec-white-space), [LineTerminators](https://tc39.es/ecma262/#prod-LineTerminator) and [Comments](https://tc39.es/ecma262/#prod-Comment) are generally allowed between any punctuators._
 
 Parser Implementations
 ----------------------

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ JSXElementName :
 
 JSXIdentifier :
 
-- [IdentifierStart](https://tc39.es/ecma262/#prod-IdentifierStart)
-- JSXIdentifier [IdentifierPart](https://tc39.es/ecma262/#prod-IdentifierPart)
+- IdentifierStart
+- JSXIdentifier IdentifierPart
 - JSXIdentifier __NO WHITESPACE OR COMMENT__ `-`
 
 JSXNamespacedName :
@@ -95,7 +95,7 @@ JSXAttributes : 
 
 JSXSpreadAttribute :
 
-- `{` `...` [AssignmentExpression](https://tc39.es/ecma262/#prod-AssignmentExpression) `}`
+- `{` `...` AssignmentExpression `}`
 
 JSXAttribute : 
 
@@ -114,8 +114,8 @@ JSXAttributeValue : 
 
 - `"` JSXDoubleStringCharacters<sub>opt</sub> `"`
 - `'` JSXSingleStringCharacters<sub>opt</sub> `'`
-- [TemplateLiteral](https://tc39.es/ecma262/#prod-Template)
-- `{` [AssignmentExpression](https://tc39.es/ecma262/#prod-AssignmentExpression) `}`
+- TemplateLiteral
+- `{` AssignmentExpression `}`
 - JSXElement
 - JSXFragment
 
@@ -133,7 +133,7 @@ JSXSingleStringCharacters : 
 
 JSXSingleStringCharacter : 
 
-- [SourceCharacter](https://tc39.es/ecma262/#prod-SourceCharacter) __but not `'`__
+- SourceCharacter __but not `'`__
 
 __Children__
 
@@ -154,16 +154,16 @@ JSXText :
 
 JSXTextCharacter :
 
-- [SourceCharacter](https://tc39.es/ecma262/#prod-SourceCharacter) __but not one of `{`, `<`, `>` or `}`__
+- SourceCharacter __but not one of `{`, `<`, `>` or `}`__
 
 JSXChildExpression :
 
-- [AssignmentExpression](https://tc39.es/ecma262/#prod-AssignmentExpression)
-- `...` [AssignmentExpression](https://tc39.es/ecma262/#prod-AssignmentExpression)
+- AssignmentExpression
+- `...` AssignmentExpression
 
 __Whitespace and Comments__
 
-_JSX uses the same punctuators and braces as ECMAScript. [WhiteSpace](https://tc39.es/ecma262/#sec-white-space), [LineTerminators](https://tc39.es/ecma262/#prod-LineTerminator) and [Comments](https://tc39.es/ecma262/#prod-Comment) are generally allowed between any punctuators._
+_JSX uses the same punctuators and braces as ECMAScript. WhiteSpace, LineTerminators and Comments are generally allowed between any punctuators._
 
 Parser Implementations
 ----------------------


### PR DESCRIPTION
Given the comments in this [Babel thread](https://github.com/babel/babel/issues/14010), here is my attempt at resolving the template string issue. This PR supports the "decode strings in the normal JavaScript manner", and my reasoning is below (there doesn't really seem to be a place to put the reasoning in the spec itself, although I have tried to clarify the encoding issues for future spec readers):

1. As stated above, this spec change has template string attributes behave identically to their JavaScript counter-parts with regard to string encoding. In other words, `` <tag name = `[value]`/> `` is identical to writing `` <tag name = { `[value]` } />``.
2. The main reasoning here is that the primary purpose of having `` <tag name = "[value]"/> `` use the HTML-style string encoding is because there is a matching syntax production in HTML that we want to emulate. As a simple example, copying `<tag name = "&amp;">` should not produce two surprisingly different results depending on whether it appears in HTML or JSX.
3. However, there is no such matching production in HTML that we are attempting to support with our template strings. Short of having the template string *incorporate* the delimiting back-ticks and ignore any internal template elements, it will never match the expected behavior of HTML. (That is to say, in HTML `` <tag name = `[value]`> `` is like writing `` <tag name = "`[value]`"> ``, with the additional complications since you don't have quote boundaries to clearly delimiter when the value ends, etc.).
4. Template strings that provide a good escape hatch from the potentially surprising html entity encoding process to give you normal JS encoding. When used without any internal template elements, you essentially get JSX attributes that encode the same as JavaScript without the additional curly brace noise.

As @sebmarkbage mentioned in the above comment, it appears the sentiment is that we wish JSX simply used JS encoding across the board, so given that template strings are a new production that pose no backwards compatibility issues, it seems like a good opportunity to introduce a way to get this behavior without introducing breaking changes. If this is a direction we want JSX to go more generally, we also would have the opportunity to start telling people to use template strings across the board as a best practice, to clearly communicate in their code that they are using a *JS version of strings* and not an HTML one. Arguably, you could someday even deprecate double and single quoted attributes in favor of these and have a similar "JSX is not HTML" message when used to how it currently says "JSX is not XML" when namespaced tags are used. All these options are of course outside the scope of this one addition, but I bring them up to demonstrate that this simple addition opens up a lot of flexibility for creating smoother transitional paths to more breaking changes that have been discussed here for years.

### NOTES

I've made a few other changes here to hopefully help people in the future:

1. I've linked Syntax productions to their ECMAScript pages.
2. I've tried to do the same with ESTree node elements (although outside the code block since you can't link there).
3. I've attempted to explicitly note the HTML attribute encoding for `JSXSingleStringCharacter` and `JSXDoubleStringCharacter` as this appears to currently be absent from the spec (please correct me if I'm wrong here). This also through omission implies that the `TemplateLiteral` syntax production behaves identically to the ECMAScript one.
4. I updated the `@babel/parser` link.

Closes #25 
Closes #112
