### PR TITLE
Fix attribute strings spec to match implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,15 @@ JSXAttributeInitializer : 
 
 JSXAttributeValue : 
 
-- `"` JSXDoubleStringCharacters<sub>opt</sub> `"`
-- `'` JSXSingleStringCharacters<sub>opt</sub> `'`
+- `"` __NO WHITESPACE OR COMMENT__ JSXDoubleStringCharacters<sub>opt</sub> __NO WHITESPACE OR COMMENT__ `"`
+- `'` __NO WHITESPACE OR COMMENT__ JSXSingleStringCharacters<sub>opt</sub> __NO WHITESPACE OR COMMENT__ `'`
 - `{` AssignmentExpression `}`
 - JSXElement
 - JSXFragment
 
 JSXDoubleStringCharacters : 
 
-- JSXDoubleStringCharacter JSXDoubleStringCharacters<sub>opt</sub>
+- JSXDoubleStringCharacter __NO WHITESPACE OR COMMENT__ JSXDoubleStringCharacters<sub>opt</sub>
 
 JSXDoubleStringCharacter : 
 
@@ -128,7 +128,7 @@ JSXDoubleStringCharacter : 
 
 JSXSingleStringCharacters : 
 
-- JSXSingleStringCharacter JSXSingleStringCharacters<sub>opt</sub>
+- JSXSingleStringCharacter __NO WHITESPACE OR COMMENT__ JSXSingleStringCharacters<sub>opt</sub>
 
 JSXSingleStringCharacter : 
 


### PR DESCRIPTION
According to my understanding of the JSX specification, the following
code should define one attribute whose name is `attr` and whose value is
`hello/*"*/world`:

    function MyComponent() {
      return <div attr="hello/*"*/world" />;
    }

However, I found no implementation which parses the code this way. All
implementations treat `/*` as part of the `JSXSingleStringCharacters`
rule rather than the beginning of a block comment.

Disallow parsing `Comment` and `WhiteSpace` rules between elements of
`JSXSingleStringCharacters`, etc. This makes the specification match
implementations.

Implementations tested, all of which agree with the modified grammar:

* @babel/parser version 7.15.3
* Flow version 0.144.0
* TypeScript version 4.0.3
* acorn version 8.3.0
* espree version 6.2.1