### PR TITLE
[Normative] Capture the HTML entity behaviors

### DIFF
--- a/index.html
+++ b/index.html
@@ -2670,13 +2670,8 @@ li.menu-search-result-term:before {
 </emu-production>
 <emu-production name="JSXText" type="lexical" id="prod-JSXText">
     <emu-nt><a href="#prod-JSXText">JSXText</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="z5eumfmp">
-<<<<<<< HEAD
         <emu-nt id="_ref_55"><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt>
         <emu-nt optional="" id="_ref_56"><a href="#prod-JSXText">JSXText</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-=======
-        <emu-nt id="_ref_47"><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt>
-        <emu-nt optional="" id="_ref_48"><a href="#prod-JSXText">JSXText</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
->>>>>>> 88c892c (fix merge)
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXTextCharacter" type="lexical" id="prod-JSXTextCharacter">

--- a/index.html
+++ b/index.html
@@ -2668,8 +2668,8 @@ li.menu-search-result-term:before {
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
-<emu-production name="JSXText" id="prod-JSXText">
-    <emu-nt><a href="#prod-JSXText">JSXText</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="z5eumfmp">
+<emu-production name="JSXText" type="lexical" id="prod-JSXText">
+    <emu-nt><a href="#prod-JSXText">JSXText</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="z5eumfmp">
         <emu-nt id="_ref_55"><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt>
         <emu-nt optional="" id="_ref_56"><a href="#prod-JSXText">JSXText</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
@@ -2694,7 +2694,7 @@ li.menu-search-result-term:before {
     <emu-clause id="sec-jsx-string-characters">
       <h1><span class="secnum">1.5.1</span> JSX String Characters</h1>
 
-      <p>Historically, string characters within <emu-nt id="_ref_57"><a href="#prod-JSXAttributeValue">JSXAttributeValue</a></emu-nt> and <emu-nt id="_ref_58"><a href="#prod-JSXText">JSXText</a></emu-nt> are extended to allow the presence of <emu-xref href="#sec-HTMLCharacterReference" id="_ref_0"><a href="#sec-HTMLCharacterReference">HTML character references</a></emu-xref> to make copy-pasting between HTML and JSX easier. We may revisit this decision in the future.</p>
+      <p>Historically, string characters within <emu-nt id="_ref_57"><a href="#prod-JSXAttributeValue">JSXAttributeValue</a></emu-nt> and <emu-nt id="_ref_58"><a href="#prod-JSXText">JSXText</a></emu-nt> are extended to allow the presence of <emu-xref href="#sec-HTMLCharacterReference" id="_ref_0"><a href="#sec-HTMLCharacterReference">HTML character references</a></emu-xref> to make copy-pasting between HTML and JSX easier, at the cost of not supporting <code>\</code> <emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-EscapeSequence">EscapeSequence</a></emu-nt> of ECMAScript's <emu-nt><a href="https://tc39.es/ecma262/#prod-StringLiteral">StringLiteral</a></emu-nt>. We may revisit this decision in the future.</p>
       
       <h2>Syntax</h2>
 
@@ -2707,15 +2707,15 @@ li.menu-search-result-term:before {
     <emu-clause id="sec-HTMLCharacterReference">
       <h1><span class="secnum">1.5.2</span> HTML Character References</h1>
       <emu-note><span class="note">Note 1</span><div class="note-contents">
-      <p>HTML character references are defined in the <a href="https://html.spec.whatwg.org/multipage/syntax.html#character-references">HTML standard</a>.</p>
+      <p>The grammars here followed <a href="https://html.spec.whatwg.org/multipage/syntax.html#character-references">the living HTML standard</a>.</p>
       </div></emu-note>
 
       <h2>Syntax</h2>
 
       <emu-grammar><emu-production name="HTMLCharacterReference" type="lexical">
-    <emu-nt>HTMLCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="ldmyv8x1"><emu-nt>XHTMLDecimalCharacterReference</emu-nt></emu-rhs>
-    <emu-rhs a="92udv0vg"><emu-nt>XHTMLHexCharacterReference</emu-nt></emu-rhs>
-    <emu-rhs a="-rh6rgss"><emu-nt>XHTMLNamedCharacterReference</emu-nt></emu-rhs>
+    <emu-nt>HTMLCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="agxgawzs"><emu-nt>HTMLDecimalCharacterReference</emu-nt></emu-rhs>
+    <emu-rhs a="y8kdlbqm"><emu-nt>HTMLHexCharacterReference</emu-nt></emu-rhs>
+    <emu-rhs a="87f0wv7v"><emu-nt>HTMLNamedCharacterReference</emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="HTMLDecimalCharacterReference" type="lexical">
     <emu-nt>HTMLDecimalCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="fo85v5rn">
@@ -2744,22 +2744,16 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="HTMLNamedCharacterReferenceName" type="lexical">
-    <emu-nt>HTMLNamedCharacterReferenceName</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="kmiuecgl"><emu-gprose>An implementations-defined list of names</emu-gprose></emu-rhs>
+    <emu-nt>HTMLNamedCharacterReferenceName</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="dhbeeq7h"><emu-gprose>List of 252 character entity references defined in HTML4 standard</emu-gprose></emu-rhs>
 </emu-production>
 </emu-grammar>
 
       <emu-note><span class="note">Note 2</span><div class="note-contents"> 
-        <p>We recommend an implementation to choose the list from either the HTML4 standard or the living HTML standard:</p>
-        <ul>
-        <li>
-        The HTML4 standard defined <a href="https://www.w3.org/TR/1999/REC-html401-19991224/sgml/entities.html">a list of 252 character entity references</a> . 
-        </li>
-        <li>
-        The living HTML standard defined <a href="https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references">a list of 2231 named character references</a> since the HTML5 standard. It also claimed that <a href="https://github.com/whatwg/html/blob/main/FAQ.md#html-should-add-more-named-character-references">this list is static and will not be expanded or changed in the future</a> to reduce support burden for languages such as JSX.
-        </li>
-        </ul>
         <p>
-          As the time of writing, both Babel and TypeScript supports only the 252 names defined in the HTML4 standard.
+          This means that the later expansion of this list to <a href="https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references">2231 named character references</a> since HTML5 are intentionally <i>excluded</i> from the support.
+        </p>
+        <p>
+          The list of 252 character entity references defined in HTML4 standard can be found <a href="https://www.w3.org/TR/1999/REC-html401-19991224/sgml/entities.html">at here</a>.
         </p>
       </div></emu-note>
     </emu-clause>
@@ -2778,18 +2772,16 @@ li.menu-search-result-term:before {
       <emu-clause type="sdo" id="sec-jsx-JSXString-SV">
         <h1><span class="secnum">1.5.3.1</span> Static Semantics: SV</h1>
         <p>An implementation may convert <emu-nt>JSXString</emu-nt> into a ECMAScript String value. In order to do this, JSX extends the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operation</a></emu-xref> <a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a> to <emu-nt>JSXStringCharacter</emu-nt>:</p> 
-        <ul>
-          <li>
-            <ins class="block">
-              The SV of <emu-grammar><emu-production name="JSXStringCharacter" type="lexical" collapsed="" class=" inline">
+        <ins class="block">
+          <ul>
+            <li>
+                The SV of <emu-grammar><emu-production name="JSXStringCharacter" type="lexical" collapsed="" class=" inline">
     <emu-nt>JSXStringCharacter</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="v3ewaosn"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt></emu-rhs>
 </emu-production>
 </emu-grammar> is the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code point matched by <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt>.
-            </ins>
-          </li>
-          <li>
-            <ins class="block">
-              The SV of <emu-grammar><emu-production name="HTMLDecimalCharacterReference" type="lexical" collapsed="" class=" inline">
+            </li>
+            <li>
+                The SV of <emu-grammar><emu-production name="HTMLDecimalCharacterReference" type="lexical" collapsed="" class=" inline">
     <emu-nt>HTMLDecimalCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="gdsompvk">
         <emu-t>&amp;</emu-t>
         <emu-t>#</emu-t>
@@ -2798,11 +2790,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>
-            </ins>
-          </li>
-          <li>
-            <ins class="block">
-              The SV of <emu-grammar><emu-production name="HTMLHexCharacterReference" type="lexical" collapsed="" class=" inline">
+            </li>
+            <li>
+                The SV of <emu-grammar><emu-production name="HTMLHexCharacterReference" type="lexical" collapsed="" class=" inline">
     <emu-nt>HTMLHexCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="e4w_lnw7">
         <emu-t>&amp;</emu-t>
         <emu-t>#</emu-t>
@@ -2812,11 +2802,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-HexDigits">HexDigits</a></emu-nt>
-            </ins>
-          </li>
-          <li>
-            <ins class="block">
-              The SV of <emu-grammar><emu-production name="HTMLNamedCharacterReference" type="lexical" collapsed="" class=" inline">
+            </li>
+            <li>
+                The SV of <emu-grammar><emu-production name="HTMLNamedCharacterReference" type="lexical" collapsed="" class=" inline">
     <emu-nt>HTMLNamedCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="er91pyag">
         <emu-t>&amp;</emu-t>
         <emu-nt>HTMLNamedCharacterReferenceName</emu-nt>
@@ -2824,9 +2812,9 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code points matched by <emu-nt>HTMLNamedCharacterReferenceName</emu-nt> according the implementation-defined list of names.
-            </ins>
-          </li>
-        </ul>
+            </li>
+          </ul>
+        </ins>
 
         <p>The exact approach to fulfill the extended sematics is <a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a>.</p>
         <emu-note><span class="note">Note</span><div class="note-contents">

--- a/index.html
+++ b/index.html
@@ -2670,8 +2670,13 @@ li.menu-search-result-term:before {
 </emu-production>
 <emu-production name="JSXText" type="lexical" id="prod-JSXText">
     <emu-nt><a href="#prod-JSXText">JSXText</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="z5eumfmp">
+<<<<<<< HEAD
         <emu-nt id="_ref_55"><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt>
         <emu-nt optional="" id="_ref_56"><a href="#prod-JSXText">JSXText</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+=======
+        <emu-nt id="_ref_47"><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt>
+        <emu-nt optional="" id="_ref_48"><a href="#prod-JSXText">JSXText</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+>>>>>>> 88c892c (fix merge)
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXTextCharacter" type="lexical" id="prod-JSXTextCharacter">

--- a/index.html
+++ b/index.html
@@ -1149,7 +1149,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 let sdoMap = JSON.parse(`{"prod-KCDyML_C":{"Early":{"clause":"1.2.1","ids":["prod-p4aAXPL4"]}}}`);
-let biblio = JSON.parse(`{"refsByClause":{"sec-jsx-PrimaryExpression":["_ref_0","_ref_1"],"sec-jsx-elements":["_ref_2","_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_9","_ref_10","_ref_11","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23"],"sec-jsx-elements-early-errors":["_ref_24","_ref_25","_ref_26","_ref_27","_ref_28","_ref_29","_ref_30"],"sec-jsx-attributes":["_ref_31","_ref_32","_ref_33","_ref_34","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45","_ref_46","_ref_47"],"sec-jsx-children":["_ref_48","_ref_49","_ref_50","_ref_51","_ref_52","_ref_53","_ref_54","_ref_55"]},"entries":[{"type":"clause","id":"sec-rationale","titleHTML":"Rationale","number":""},{"type":"clause","id":"sec-intro","titleHTML":"Introduction","number":""},{"type":"clause","id":"sec-jsx-PrimaryExpression","titleHTML":"Modified Productions","number":"1.1"},{"type":"production","id":"prod-JSXElement","name":"JSXElement","referencingIds":["_ref_0","_ref_42","_ref_51"]},{"type":"production","id":"prod-JSXSelfClosingElement","name":"JSXSelfClosingElement","referencingIds":["_ref_2"]},{"type":"production","id":"prod-JSXOpeningElement","name":"JSXOpeningElement","referencingIds":["_ref_3","_ref_24","_ref_28"]},{"type":"production","id":"prod-JSXClosingElement","name":"JSXClosingElement","referencingIds":["_ref_5","_ref_26","_ref_30"]},{"type":"production","id":"prod-JSXFragment","name":"JSXFragment","referencingIds":["_ref_1","_ref_43","_ref_52"]},{"type":"production","id":"prod-JSXElementName","name":"JSXElementName","referencingIds":["_ref_6","_ref_8","_ref_10","_ref_27","_ref_29"]},{"type":"production","id":"prod-JSXIdentifier","name":"JSXIdentifier","referencingIds":["_ref_12","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_23","_ref_37"]},{"type":"production","id":"prod-JSXNamespacedName","name":"JSXNamespacedName","referencingIds":["_ref_13","_ref_38"]},{"type":"production","id":"prod-JSXMemberExpression","name":"JSXMemberExpression","referencingIds":["_ref_14","_ref_22"]},{"type":"clause","id":"sec-jsx-elements-early-errors","titleHTML":"Static Semantics: Early Errors","number":"1.2.1"},{"type":"clause","id":"sec-jsx-elements","titleHTML":"JSX Elements","number":"1.2"},{"type":"production","id":"prod-JSXAttributes","name":"JSXAttributes","referencingIds":["_ref_7","_ref_9","_ref_32","_ref_34"]},{"type":"production","id":"prod-JSXSpreadAttribute","name":"JSXSpreadAttribute","referencingIds":["_ref_31"]},{"type":"production","id":"prod-JSXAttribute","name":"JSXAttribute","referencingIds":["_ref_33"]},{"type":"production","id":"prod-JSXAttributeName","name":"JSXAttributeName","referencingIds":["_ref_35"]},{"type":"production","id":"prod-JSXAttributeInitializer","name":"JSXAttributeInitializer","referencingIds":["_ref_36"]},{"type":"production","id":"prod-JSXAttributeValue","name":"JSXAttributeValue","referencingIds":["_ref_39"]},{"type":"production","id":"prod-JSXDoubleStringCharacters","name":"JSXDoubleStringCharacters","referencingIds":["_ref_40","_ref_45"]},{"type":"production","id":"prod-JSXDoubleStringCharacter","name":"JSXDoubleStringCharacter","referencingIds":["_ref_44"]},{"type":"production","id":"prod-JSXSingleStringCharacters","name":"JSXSingleStringCharacters","referencingIds":["_ref_41","_ref_47"]},{"type":"production","id":"prod-JSXSingleStringCharacter","name":"JSXSingleStringCharacter","referencingIds":["_ref_46"]},{"type":"clause","id":"sec-jsx-attributes","titleHTML":"JSX Attributes","number":"1.3"},{"type":"production","id":"prod-JSXChildren","name":"JSXChildren","referencingIds":["_ref_4","_ref_11","_ref_25","_ref_49"]},{"type":"production","id":"prod-JSXChild","name":"JSXChild","referencingIds":["_ref_48"]},{"type":"production","id":"prod-JSXText","name":"JSXText","referencingIds":["_ref_50","_ref_55"]},{"type":"production","id":"prod-JSXTextCharacter","name":"JSXTextCharacter","referencingIds":["_ref_54"]},{"type":"production","id":"prod-JSXChildExpression","name":"JSXChildExpression","referencingIds":["_ref_53"]},{"type":"clause","id":"sec-jsx-children","titleHTML":"JSX Children","number":"1.4"},{"type":"clause","id":"sec-jsx-grammar","titleHTML":"JSX Definition","number":"1"},{"type":"clause","id":"sec-why-not-template-literals","titleHTML":"Why not Template Literals?","number":"A"},{"type":"clause","id":"sec-why-not-JXON","titleHTML":"Why not JXON?","number":"B"},{"type":"clause","id":"sec-prior-art","titleHTML":"Prior Art","number":"C"},{"type":"clause","id":"sec-license","titleHTML":"License","number":"D"}]}`);
+let biblio = JSON.parse(`{"refsByClause":{"sec-jsx-string-characters":["_ref_0","_ref_57","_ref_58"],"sec-jsx-PrimaryExpression":["_ref_1","_ref_2"],"sec-jsx-elements":["_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_9","_ref_10","_ref_11","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23","_ref_24"],"sec-jsx-elements-early-errors":["_ref_25","_ref_26","_ref_27","_ref_28","_ref_29","_ref_30","_ref_31"],"sec-jsx-attributes":["_ref_32","_ref_33","_ref_34","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45","_ref_46","_ref_47","_ref_48"],"sec-jsx-children":["_ref_49","_ref_50","_ref_51","_ref_52","_ref_53","_ref_54","_ref_55","_ref_56"],"sec-jsx-JSXString":["_ref_59","_ref_60","_ref_61"]},"entries":[{"type":"clause","id":"sec-rationale","titleHTML":"Rationale","number":""},{"type":"clause","id":"sec-intro","titleHTML":"Introduction","number":""},{"type":"clause","id":"sec-jsx-PrimaryExpression","titleHTML":"Modified Productions","number":"1.1"},{"type":"production","id":"prod-JSXElement","name":"JSXElement","referencingIds":["_ref_1","_ref_43","_ref_52"]},{"type":"production","id":"prod-JSXSelfClosingElement","name":"JSXSelfClosingElement","referencingIds":["_ref_3"]},{"type":"production","id":"prod-JSXOpeningElement","name":"JSXOpeningElement","referencingIds":["_ref_4","_ref_25","_ref_29"]},{"type":"production","id":"prod-JSXClosingElement","name":"JSXClosingElement","referencingIds":["_ref_6","_ref_27","_ref_31"]},{"type":"production","id":"prod-JSXFragment","name":"JSXFragment","referencingIds":["_ref_2","_ref_44","_ref_53"]},{"type":"production","id":"prod-JSXElementName","name":"JSXElementName","referencingIds":["_ref_7","_ref_9","_ref_11","_ref_28","_ref_30"]},{"type":"production","id":"prod-JSXIdentifier","name":"JSXIdentifier","referencingIds":["_ref_13","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_24","_ref_38"]},{"type":"production","id":"prod-JSXNamespacedName","name":"JSXNamespacedName","referencingIds":["_ref_14","_ref_39"]},{"type":"production","id":"prod-JSXMemberExpression","name":"JSXMemberExpression","referencingIds":["_ref_15","_ref_23"]},{"type":"clause","id":"sec-jsx-elements-early-errors","titleHTML":"Static Semantics: Early Errors","number":"1.2.1"},{"type":"clause","id":"sec-jsx-elements","titleHTML":"JSX Elements","number":"1.2"},{"type":"production","id":"prod-JSXAttributes","name":"JSXAttributes","referencingIds":["_ref_8","_ref_10","_ref_33","_ref_35"]},{"type":"production","id":"prod-JSXSpreadAttribute","name":"JSXSpreadAttribute","referencingIds":["_ref_32"]},{"type":"production","id":"prod-JSXAttribute","name":"JSXAttribute","referencingIds":["_ref_34"]},{"type":"production","id":"prod-JSXAttributeName","name":"JSXAttributeName","referencingIds":["_ref_36"]},{"type":"production","id":"prod-JSXAttributeInitializer","name":"JSXAttributeInitializer","referencingIds":["_ref_37"]},{"type":"production","id":"prod-JSXAttributeValue","name":"JSXAttributeValue","referencingIds":["_ref_40","_ref_57"]},{"type":"production","id":"prod-JSXDoubleStringCharacters","name":"JSXDoubleStringCharacters","referencingIds":["_ref_41","_ref_46","_ref_59"]},{"type":"production","id":"prod-JSXDoubleStringCharacter","name":"JSXDoubleStringCharacter","referencingIds":["_ref_45"]},{"type":"production","id":"prod-JSXSingleStringCharacters","name":"JSXSingleStringCharacters","referencingIds":["_ref_42","_ref_48","_ref_60"]},{"type":"production","id":"prod-JSXSingleStringCharacter","name":"JSXSingleStringCharacter","referencingIds":["_ref_47"]},{"type":"clause","id":"sec-jsx-attributes","titleHTML":"JSX Attributes","number":"1.3"},{"type":"production","id":"prod-JSXChildren","name":"JSXChildren","referencingIds":["_ref_5","_ref_12","_ref_26","_ref_50"]},{"type":"production","id":"prod-JSXChild","name":"JSXChild","referencingIds":["_ref_49"]},{"type":"production","id":"prod-JSXText","name":"JSXText","referencingIds":["_ref_51","_ref_56","_ref_58","_ref_61"]},{"type":"production","id":"prod-JSXTextCharacter","name":"JSXTextCharacter","referencingIds":["_ref_55"]},{"type":"production","id":"prod-JSXChildExpression","name":"JSXChildExpression","referencingIds":["_ref_54"]},{"type":"clause","id":"sec-jsx-children","titleHTML":"JSX Children","number":"1.4"},{"type":"clause","id":"sec-jsx-string-characters","titleHTML":"JSX String Characters","number":"1.5.1"},{"type":"clause","id":"sec-HTMLCharacterReference","titleHTML":"HTML Character References","number":"1.5.2","referencingIds":["_ref_0"]},{"type":"clause","id":"sec-jsx-JSXString-SV","titleHTML":"Static Semantics: SV","number":"1.5.3.1"},{"type":"clause","id":"sec-jsx-JSXString","titleHTML":"JSX String Definition","number":"1.5.3"},{"type":"clause","id":"sec-jsx-string","titleHTML":"JSX Strings","number":"1.5"},{"type":"clause","id":"sec-jsx","titleHTML":"JSX Definition","number":"1"},{"type":"clause","id":"sec-why-not-template-literals","titleHTML":"Why not Template Literals?","number":"A"},{"type":"clause","id":"sec-why-not-JXON","titleHTML":"Why not JXON?","number":"B"},{"type":"clause","id":"sec-prior-art","titleHTML":"Prior Art","number":"C"},{"type":"clause","id":"sec-license","titleHTML":"License","number":"D"}]}`);
 ;let usesMultipage = false</script><style>body {
   display: flex;
   font-size: 18px;
@@ -2414,7 +2414,7 @@ li.menu-search-result-term:before {
 </ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
       <title>Menu</title>
       <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
-    </svg></div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intro" title="Introduction">Introduction</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-rationale" title="Rationale">Rationale</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-grammar" title="JSX Definition"><span class="secnum">1</span> JSX Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-PrimaryExpression" title="Modified Productions"><span class="secnum">1.1</span> Modified Productions</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-elements" title="JSX Elements"><span class="secnum">1.2</span> JSX Elements</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-elements-early-errors" title="Static Semantics: Early Errors"><span class="secnum">1.2.1</span> SS: Early Errors</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-attributes" title="JSX Attributes"><span class="secnum">1.3</span> JSX Attributes</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-children" title="JSX Children"><span class="secnum">1.4</span> JSX Children</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-template-literals" title="Why not Template Literals?"><span class="secnum">A</span> Why not Template Literals?</a></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-JXON" title="Why not JXON?"><span class="secnum">B</span> Why not JXON?</a></li><li><span class="item-toggle-none"></span><a href="#sec-prior-art" title="Prior Art"><span class="secnum">C</span> Prior Art</a></li><li><span class="item-toggle-none"></span><a href="#sec-license" title="License"><span class="secnum">D</span> License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Draft / February 28, 2022</h1><h1 class="title">JSX</h1>
+    </svg></div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intro" title="Introduction">Introduction</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-rationale" title="Rationale">Rationale</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-jsx" title="JSX Definition"><span class="secnum">1</span> JSX Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-PrimaryExpression" title="Modified Productions"><span class="secnum">1.1</span> Modified Productions</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-elements" title="JSX Elements"><span class="secnum">1.2</span> JSX Elements</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-elements-early-errors" title="Static Semantics: Early Errors"><span class="secnum">1.2.1</span> SS: Early Errors</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-attributes" title="JSX Attributes"><span class="secnum">1.3</span> JSX Attributes</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-children" title="JSX Children"><span class="secnum">1.4</span> JSX Children</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-string" title="JSX Strings"><span class="secnum">1.5</span> JSX Strings</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-string-characters" title="JSX String Characters"><span class="secnum">1.5.1</span> JSX String Characters</a></li><li><span class="item-toggle-none"></span><a href="#sec-HTMLCharacterReference" title="HTML Character References"><span class="secnum">1.5.2</span> HTML Character References</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-JSXString" title="JSX String Definition"><span class="secnum">1.5.3</span> JSX String Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-JSXString-SV" title="Static Semantics: SV"><span class="secnum">1.5.3.1</span> SS: SV</a></li></ol></li></ol></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-template-literals" title="Why not Template Literals?"><span class="secnum">A</span> Why not Template Literals?</a></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-JXON" title="Why not JXON?"><span class="secnum">B</span> Why not JXON?</a></li><li><span class="item-toggle-none"></span><a href="#sec-prior-art" title="Prior Art"><span class="secnum">C</span> Prior Art</a></li><li><span class="item-toggle-none"></span><a href="#sec-license" title="License"><span class="secnum">D</span> License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Draft / February 28, 2022</h1><h1 class="title">JSX</h1>
 
 <emu-intro id="sec-intro">
   <h1>Introduction</h1>
@@ -2447,7 +2447,7 @@ li.menu-search-result-term:before {
 </emu-intro>
 
 
-<emu-clause id="sec-jsx-grammar">
+<emu-clause id="sec-jsx">
   <h1><span class="secnum">1</span> JSX Definition</h1>
 
   <emu-clause id="sec-jsx-PrimaryExpression">
@@ -2456,8 +2456,8 @@ li.menu-search-result-term:before {
 
     <h2>Syntax</h2>
     <emu-grammar><emu-production name="PrimaryExpression">
-    <emu-nt><a href="https://tc39.es/ecma262/#prod-PrimaryExpression">PrimaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <ins><emu-rhs a="ylbqkuqt"><emu-nt id="_ref_0"><a href="#prod-JSXElement">JSXElement</a></emu-nt></emu-rhs></ins>
-    <ins><emu-rhs a="xcc8tnvu"><emu-nt id="_ref_1"><a href="#prod-JSXFragment">JSXFragment</a></emu-nt></emu-rhs></ins>
+    <emu-nt><a href="https://tc39.es/ecma262/#prod-PrimaryExpression">PrimaryExpression</a></emu-nt> <emu-geq>:</emu-geq> <ins><emu-rhs a="ylbqkuqt"><emu-nt id="_ref_1"><a href="#prod-JSXElement">JSXElement</a></emu-nt></emu-rhs></ins>
+    <ins><emu-rhs a="xcc8tnvu"><emu-nt id="_ref_2"><a href="#prod-JSXFragment">JSXFragment</a></emu-nt></emu-rhs></ins>
 </emu-production>
 </emu-grammar>
   </emu-clause>
@@ -2467,18 +2467,18 @@ li.menu-search-result-term:before {
     <h2>Syntax</h2>
 
     <emu-grammar type="definition"><emu-production name="JSXElement" id="prod-JSXElement">
-    <emu-nt><a href="#prod-JSXElement">JSXElement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="b5zyfdt9"><emu-nt id="_ref_2"><a href="#prod-JSXSelfClosingElement">JSXSelfClosingElement</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-JSXElement">JSXElement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="b5zyfdt9"><emu-nt id="_ref_3"><a href="#prod-JSXSelfClosingElement">JSXSelfClosingElement</a></emu-nt></emu-rhs>
     <emu-rhs a="urykrh2r" id="prod-KCDyML_C">
-        <emu-nt id="_ref_3"><a href="#prod-JSXOpeningElement">JSXOpeningElement</a></emu-nt>
-        <emu-nt optional="" id="_ref_4"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_5"><a href="#prod-JSXClosingElement">JSXClosingElement</a></emu-nt>
+        <emu-nt id="_ref_4"><a href="#prod-JSXOpeningElement">JSXOpeningElement</a></emu-nt>
+        <emu-nt optional="" id="_ref_5"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_6"><a href="#prod-JSXClosingElement">JSXClosingElement</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXSelfClosingElement" id="prod-JSXSelfClosingElement">
     <emu-nt><a href="#prod-JSXSelfClosingElement">JSXSelfClosingElement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="dq-0kzot">
         <emu-t>&lt;</emu-t>
-        <emu-nt id="_ref_6"><a href="#prod-JSXElementName">JSXElementName</a></emu-nt>
-        <emu-nt optional="" id="_ref_7"><a href="#prod-JSXAttributes">JSXAttributes</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_7"><a href="#prod-JSXElementName">JSXElementName</a></emu-nt>
+        <emu-nt optional="" id="_ref_8"><a href="#prod-JSXAttributes">JSXAttributes</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>/</emu-t>
         <emu-t>&gt;</emu-t>
     </emu-rhs>
@@ -2486,8 +2486,8 @@ li.menu-search-result-term:before {
 <emu-production name="JSXOpeningElement" id="prod-JSXOpeningElement">
     <emu-nt><a href="#prod-JSXOpeningElement">JSXOpeningElement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="kg9_qgaz">
         <emu-t>&lt;</emu-t>
-        <emu-nt id="_ref_8"><a href="#prod-JSXElementName">JSXElementName</a></emu-nt>
-        <emu-nt optional="" id="_ref_9"><a href="#prod-JSXAttributes">JSXAttributes</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_9"><a href="#prod-JSXElementName">JSXElementName</a></emu-nt>
+        <emu-nt optional="" id="_ref_10"><a href="#prod-JSXAttributes">JSXAttributes</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>&gt;</emu-t>
     </emu-rhs>
 </emu-production>
@@ -2495,7 +2495,7 @@ li.menu-search-result-term:before {
     <emu-nt><a href="#prod-JSXClosingElement">JSXClosingElement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="bhoep6g6">
         <emu-t>&lt;</emu-t>
         <emu-t>/</emu-t>
-        <emu-nt id="_ref_10"><a href="#prod-JSXElementName">JSXElementName</a></emu-nt>
+        <emu-nt id="_ref_11"><a href="#prod-JSXElementName">JSXElementName</a></emu-nt>
         <emu-t>&gt;</emu-t>
     </emu-rhs>
 </emu-production>
@@ -2503,25 +2503,25 @@ li.menu-search-result-term:before {
     <emu-nt><a href="#prod-JSXFragment">JSXFragment</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="glzxgj5o">
         <emu-t>&lt;</emu-t>
         <emu-t>&gt;</emu-t>
-        <emu-nt optional="" id="_ref_11"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_12"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>&lt;</emu-t>
         <emu-t>/</emu-t>
         <emu-t>&gt;</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXElementName" id="prod-JSXElementName">
-    <emu-nt><a href="#prod-JSXElementName">JSXElementName</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ehd8jr3p"><emu-nt id="_ref_12"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt></emu-rhs>
-    <emu-rhs a="xmeipvkx"><emu-nt id="_ref_13"><a href="#prod-JSXNamespacedName">JSXNamespacedName</a></emu-nt></emu-rhs>
-    <emu-rhs a="o4pa_wld"><emu-nt id="_ref_14"><a href="#prod-JSXMemberExpression">JSXMemberExpression</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-JSXElementName">JSXElementName</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ehd8jr3p"><emu-nt id="_ref_13"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt></emu-rhs>
+    <emu-rhs a="xmeipvkx"><emu-nt id="_ref_14"><a href="#prod-JSXNamespacedName">JSXNamespacedName</a></emu-nt></emu-rhs>
+    <emu-rhs a="o4pa_wld"><emu-nt id="_ref_15"><a href="#prod-JSXMemberExpression">JSXMemberExpression</a></emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="JSXIdentifier" id="prod-JSXIdentifier">
     <emu-nt><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="q0afq8g8"><emu-nt><a href="https://tc39.es/ecma262/#prod-IdentifierStart">IdentifierStart</a></emu-nt></emu-rhs>
     <emu-rhs a="wb5wvggw">
-        <emu-nt id="_ref_15"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
+        <emu-nt id="_ref_16"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-IdentifierPart">IdentifierPart</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="mzgqbah0">
-        <emu-nt id="_ref_16"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
+        <emu-nt id="_ref_17"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
         <emu-gann>[no <emu-nt><a href="https://tc39.es/ecma262/#prod-WhiteSpace">WhiteSpace</a></emu-nt> or <emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-Comment">Comment</a></emu-nt> here]</emu-gann>
         <emu-t>-</emu-t>
     </emu-rhs>
@@ -2529,26 +2529,26 @@ li.menu-search-result-term:before {
 </emu-grammar>
 
     <emu-note><span class="note">Note</span><div class="note-contents">
-      The grammar of <emu-nt id="_ref_17"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt> is not parameterized the same way <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-Identifier">Identifier</a></emu-nt> is. This means that <code>&lt;await /&gt;</code> is still a valid production when "[await]" appears during the derivation.
+      The grammar of <emu-nt id="_ref_18"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt> is not parameterized the same way <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-Identifier">Identifier</a></emu-nt> is. This means that <code>&lt;await /&gt;</code> is still a valid production when "[await]" appears during the derivation.
     </div></emu-note>
 
     <emu-grammar type="definition"><emu-production name="JSXNamespacedName" id="prod-JSXNamespacedName">
     <emu-nt><a href="#prod-JSXNamespacedName">JSXNamespacedName</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="mhf25omg">
-        <emu-nt id="_ref_18"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
-        <emu-t>:</emu-t>
         <emu-nt id="_ref_19"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
+        <emu-t>:</emu-t>
+        <emu-nt id="_ref_20"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXMemberExpression" id="prod-JSXMemberExpression">
     <emu-nt><a href="#prod-JSXMemberExpression">JSXMemberExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="si4-esnv">
-        <emu-nt id="_ref_20"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
-        <emu-t>.</emu-t>
         <emu-nt id="_ref_21"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
+        <emu-t>.</emu-t>
+        <emu-nt id="_ref_22"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="y0hgepyh">
-        <emu-nt id="_ref_22"><a href="#prod-JSXMemberExpression">JSXMemberExpression</a></emu-nt>
+        <emu-nt id="_ref_23"><a href="#prod-JSXMemberExpression">JSXMemberExpression</a></emu-nt>
         <emu-t>.</emu-t>
-        <emu-nt id="_ref_23"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
+        <emu-nt id="_ref_24"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
@@ -2557,14 +2557,14 @@ li.menu-search-result-term:before {
       <h1><span class="secnum">1.2.1</span> Static Semantics: Early Errors</h1>
       <emu-grammar><emu-production name="JSXElement" collapsed="">
     <emu-nt><a href="#prod-JSXElement">JSXElement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="urykrh2r" id="prod-p4aAXPL4">
-        <emu-nt id="_ref_24"><a href="#prod-JSXOpeningElement">JSXOpeningElement</a></emu-nt>
-        <emu-nt optional="" id="_ref_25"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_26"><a href="#prod-JSXClosingElement">JSXClosingElement</a></emu-nt>
+        <emu-nt id="_ref_25"><a href="#prod-JSXOpeningElement">JSXOpeningElement</a></emu-nt>
+        <emu-nt optional="" id="_ref_26"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_27"><a href="#prod-JSXClosingElement">JSXClosingElement</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
       <ul>
-        <li>It is a Syntax Error if the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">source text matched by</a></emu-xref> the <emu-nt id="_ref_27"><a href="#prod-JSXElementName">JSXElementName</a></emu-nt> of <emu-nt id="_ref_28"><a href="#prod-JSXOpeningElement">JSXOpeningElement</a></emu-nt> does not equal to the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">source text matched by</a></emu-xref> the <emu-nt id="_ref_29"><a href="#prod-JSXElementName">JSXElementName</a></emu-nt> of <emu-nt id="_ref_30"><a href="#prod-JSXClosingElement">JSXClosingElement</a></emu-nt>.</li>
+        <li>It is a Syntax Error if the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">source text matched by</a></emu-xref> the <emu-nt id="_ref_28"><a href="#prod-JSXElementName">JSXElementName</a></emu-nt> of <emu-nt id="_ref_29"><a href="#prod-JSXOpeningElement">JSXOpeningElement</a></emu-nt> does not equal to the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">source text matched by</a></emu-xref> the <emu-nt id="_ref_30"><a href="#prod-JSXElementName">JSXElementName</a></emu-nt> of <emu-nt id="_ref_31"><a href="#prod-JSXClosingElement">JSXClosingElement</a></emu-nt>.</li>
       </ul>
     </emu-clause>
 
@@ -2576,12 +2576,12 @@ li.menu-search-result-term:before {
 
     <emu-grammar type="definition"><emu-production name="JSXAttributes" id="prod-JSXAttributes">
     <emu-nt><a href="#prod-JSXAttributes">JSXAttributes</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="5mcgceuv">
-        <emu-nt id="_ref_31"><a href="#prod-JSXSpreadAttribute">JSXSpreadAttribute</a></emu-nt>
-        <emu-nt optional="" id="_ref_32"><a href="#prod-JSXAttributes">JSXAttributes</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_32"><a href="#prod-JSXSpreadAttribute">JSXSpreadAttribute</a></emu-nt>
+        <emu-nt optional="" id="_ref_33"><a href="#prod-JSXAttributes">JSXAttributes</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
     <emu-rhs a="dzdrzxq-">
-        <emu-nt id="_ref_33"><a href="#prod-JSXAttribute">JSXAttribute</a></emu-nt>
-        <emu-nt optional="" id="_ref_34"><a href="#prod-JSXAttributes">JSXAttributes</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_34"><a href="#prod-JSXAttribute">JSXAttribute</a></emu-nt>
+        <emu-nt optional="" id="_ref_35"><a href="#prod-JSXAttributes">JSXAttributes</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXSpreadAttribute" id="prod-JSXSpreadAttribute">
@@ -2594,29 +2594,29 @@ li.menu-search-result-term:before {
 </emu-production>
 <emu-production name="JSXAttribute" id="prod-JSXAttribute">
     <emu-nt><a href="#prod-JSXAttribute">JSXAttribute</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="tveyz-zf">
-        <emu-nt id="_ref_35"><a href="#prod-JSXAttributeName">JSXAttributeName</a></emu-nt>
-        <emu-nt optional="" id="_ref_36"><a href="#prod-JSXAttributeInitializer">JSXAttributeInitializer</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_36"><a href="#prod-JSXAttributeName">JSXAttributeName</a></emu-nt>
+        <emu-nt optional="" id="_ref_37"><a href="#prod-JSXAttributeInitializer">JSXAttributeInitializer</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXAttributeName" id="prod-JSXAttributeName">
-    <emu-nt><a href="#prod-JSXAttributeName">JSXAttributeName</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ehd8jr3p"><emu-nt id="_ref_37"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt></emu-rhs>
-    <emu-rhs a="xmeipvkx"><emu-nt id="_ref_38"><a href="#prod-JSXNamespacedName">JSXNamespacedName</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-JSXAttributeName">JSXAttributeName</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ehd8jr3p"><emu-nt id="_ref_38"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt></emu-rhs>
+    <emu-rhs a="xmeipvkx"><emu-nt id="_ref_39"><a href="#prod-JSXNamespacedName">JSXNamespacedName</a></emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="JSXAttributeInitializer" id="prod-JSXAttributeInitializer">
     <emu-nt><a href="#prod-JSXAttributeInitializer">JSXAttributeInitializer</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="sfj32tqz">
         <emu-t>=</emu-t>
-        <emu-nt id="_ref_39"><a href="#prod-JSXAttributeValue">JSXAttributeValue</a></emu-nt>
+        <emu-nt id="_ref_40"><a href="#prod-JSXAttributeValue">JSXAttributeValue</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXAttributeValue" id="prod-JSXAttributeValue">
     <emu-nt><a href="#prod-JSXAttributeValue">JSXAttributeValue</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="oyac4vtf">
         <emu-t>"</emu-t>
-        <emu-nt optional="" id="_ref_40"><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_41"><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>"</emu-t>
     </emu-rhs>
     <emu-rhs a="j6v80tpm">
         <emu-t>'</emu-t>
-        <emu-nt optional="" id="_ref_41"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_42"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>'</emu-t>
     </emu-rhs>
     <emu-rhs a="0kze3tr4">
@@ -2624,26 +2624,26 @@ li.menu-search-result-term:before {
         <emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
-    <emu-rhs a="ylbqkuqt"><emu-nt id="_ref_42"><a href="#prod-JSXElement">JSXElement</a></emu-nt></emu-rhs>
-    <emu-rhs a="xcc8tnvu"><emu-nt id="_ref_43"><a href="#prod-JSXFragment">JSXFragment</a></emu-nt></emu-rhs>
+    <emu-rhs a="ylbqkuqt"><emu-nt id="_ref_43"><a href="#prod-JSXElement">JSXElement</a></emu-nt></emu-rhs>
+    <emu-rhs a="xcc8tnvu"><emu-nt id="_ref_44"><a href="#prod-JSXFragment">JSXFragment</a></emu-nt></emu-rhs>
 </emu-production>
-<emu-production name="JSXDoubleStringCharacters" id="prod-JSXDoubleStringCharacters">
-    <emu-nt><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="yodnvall">
-        <emu-nt id="_ref_44"><a href="#prod-JSXDoubleStringCharacter">JSXDoubleStringCharacter</a></emu-nt>
-        <emu-nt optional="" id="_ref_45"><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+<emu-production name="JSXDoubleStringCharacters" type="lexical" id="prod-JSXDoubleStringCharacters">
+    <emu-nt><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="yodnvall">
+        <emu-nt id="_ref_45"><a href="#prod-JSXDoubleStringCharacter">JSXDoubleStringCharacter</a></emu-nt>
+        <emu-nt optional="" id="_ref_46"><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
-<emu-production name="JSXDoubleStringCharacter" id="prod-JSXDoubleStringCharacter">
-    <emu-nt><a href="#prod-JSXDoubleStringCharacter">JSXDoubleStringCharacter</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ha2dt7pv"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not <emu-t>"</emu-t></emu-gmod></emu-rhs>
+<emu-production name="JSXDoubleStringCharacter" type="lexical" id="prod-JSXDoubleStringCharacter">
+    <emu-nt><a href="#prod-JSXDoubleStringCharacter">JSXDoubleStringCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="nfdqsh-q"><emu-nt>JSXStringCharacter</emu-nt> <emu-gmod>but not <emu-t>"</emu-t></emu-gmod></emu-rhs>
 </emu-production>
-<emu-production name="JSXSingleStringCharacters" id="prod-JSXSingleStringCharacters">
-    <emu-nt><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="xebljaxt">
-        <emu-nt id="_ref_46"><a href="#prod-JSXSingleStringCharacter">JSXSingleStringCharacter</a></emu-nt>
-        <emu-nt optional="" id="_ref_47"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+<emu-production name="JSXSingleStringCharacters" type="lexical" id="prod-JSXSingleStringCharacters">
+    <emu-nt><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="xebljaxt">
+        <emu-nt id="_ref_47"><a href="#prod-JSXSingleStringCharacter">JSXSingleStringCharacter</a></emu-nt>
+        <emu-nt optional="" id="_ref_48"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
-<emu-production name="JSXSingleStringCharacter" id="prod-JSXSingleStringCharacter">
-    <emu-nt><a href="#prod-JSXSingleStringCharacter">JSXSingleStringCharacter</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="-ejk7lqw"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not <emu-t>'</emu-t></emu-gmod></emu-rhs>
+<emu-production name="JSXSingleStringCharacter" type="lexical" id="prod-JSXSingleStringCharacter">
+    <emu-nt><a href="#prod-JSXSingleStringCharacter">JSXSingleStringCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="rqns83ga"><emu-nt>JSXStringCharacter</emu-nt> <emu-gmod>but not <emu-t>'</emu-t></emu-gmod></emu-rhs>
 </emu-production>
 </emu-grammar>
   </emu-clause>
@@ -2654,28 +2654,28 @@ li.menu-search-result-term:before {
 
     <emu-grammar type="definition"><emu-production name="JSXChildren" id="prod-JSXChildren">
     <emu-nt><a href="#prod-JSXChildren">JSXChildren</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ey07n052">
-        <emu-nt id="_ref_48"><a href="#prod-JSXChild">JSXChild</a></emu-nt>
-        <emu-nt optional="" id="_ref_49"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_49"><a href="#prod-JSXChild">JSXChild</a></emu-nt>
+        <emu-nt optional="" id="_ref_50"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXChild" id="prod-JSXChild">
-    <emu-nt><a href="#prod-JSXChild">JSXChild</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="iwpkswln"><emu-nt id="_ref_50"><a href="#prod-JSXText">JSXText</a></emu-nt></emu-rhs>
-    <emu-rhs a="ylbqkuqt"><emu-nt id="_ref_51"><a href="#prod-JSXElement">JSXElement</a></emu-nt></emu-rhs>
-    <emu-rhs a="xcc8tnvu"><emu-nt id="_ref_52"><a href="#prod-JSXFragment">JSXFragment</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-JSXChild">JSXChild</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="iwpkswln"><emu-nt id="_ref_51"><a href="#prod-JSXText">JSXText</a></emu-nt></emu-rhs>
+    <emu-rhs a="ylbqkuqt"><emu-nt id="_ref_52"><a href="#prod-JSXElement">JSXElement</a></emu-nt></emu-rhs>
+    <emu-rhs a="xcc8tnvu"><emu-nt id="_ref_53"><a href="#prod-JSXFragment">JSXFragment</a></emu-nt></emu-rhs>
     <emu-rhs a="7t9rmusx">
         <emu-t>{</emu-t>
-        <emu-nt optional="" id="_ref_53"><a href="#prod-JSXChildExpression">JSXChildExpression</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_54"><a href="#prod-JSXChildExpression">JSXChildExpression</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXText" id="prod-JSXText">
     <emu-nt><a href="#prod-JSXText">JSXText</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="z5eumfmp">
-        <emu-nt id="_ref_54"><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt>
-        <emu-nt optional="" id="_ref_55"><a href="#prod-JSXText">JSXText</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_55"><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt>
+        <emu-nt optional="" id="_ref_56"><a href="#prod-JSXText">JSXText</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
-<emu-production name="JSXTextCharacter" id="prod-JSXTextCharacter">
-    <emu-nt><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="9cx_g9a9"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not one of <emu-t>{</emu-t> or <emu-t>&lt;</emu-t> or <emu-t>&gt;</emu-t> or <emu-t>}</emu-t></emu-gmod></emu-rhs>
+<emu-production name="JSXTextCharacter" type="lexical" id="prod-JSXTextCharacter">
+    <emu-nt><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="r679bmul"><emu-nt>JSXStringCharacter</emu-nt> <emu-gmod>but not one of <emu-t>{</emu-t> or <emu-t>&lt;</emu-t> or <emu-t>&gt;</emu-t> or <emu-t>}</emu-t></emu-gmod></emu-rhs>
 </emu-production>
 <emu-production name="JSXChildExpression" id="prod-JSXChildExpression">
     <emu-nt><a href="#prod-JSXChildExpression">JSXChildExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="1px9pijq"><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt></emu-rhs>
@@ -2685,6 +2685,155 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 </emu-grammar>
+  </emu-clause>
+
+  <emu-clause id="sec-jsx-string">
+    <h1><span class="secnum">1.5</span> JSX Strings</h1>
+
+
+    <emu-clause id="sec-jsx-string-characters">
+      <h1><span class="secnum">1.5.1</span> JSX String Characters</h1>
+
+      <p>Historically, string characters within <emu-nt id="_ref_57"><a href="#prod-JSXAttributeValue">JSXAttributeValue</a></emu-nt> and <emu-nt id="_ref_58"><a href="#prod-JSXText">JSXText</a></emu-nt> are extended to allow the presence of <emu-xref href="#sec-HTMLCharacterReference" id="_ref_0"><a href="#sec-HTMLCharacterReference">HTML character references</a></emu-xref> to make copy-pasting between HTML and JSX easier. We may revisit this decision in the future.</p>
+      
+      <h2>Syntax</h2>
+
+      <emu-grammar><emu-production name="JSXStringCharacter" type="lexical">
+    <emu-nt>JSXStringCharacter</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="uudq6psd"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not one of <emu-nt>HTMLCharacterReference</emu-nt></emu-gmod></emu-rhs>
+</emu-production>
+</emu-grammar>
+    </emu-clause>
+
+    <emu-clause id="sec-HTMLCharacterReference">
+      <h1><span class="secnum">1.5.2</span> HTML Character References</h1>
+      <emu-note><span class="note">Note 1</span><div class="note-contents">
+      <p>HTML character references are defined in the <a href="https://html.spec.whatwg.org/multipage/syntax.html#character-references">HTML standard</a>.</p>
+      </div></emu-note>
+
+      <h2>Syntax</h2>
+
+      <emu-grammar><emu-production name="HTMLCharacterReference" type="lexical">
+    <emu-nt>HTMLCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="ldmyv8x1"><emu-nt>XHTMLDecimalCharacterReference</emu-nt></emu-rhs>
+    <emu-rhs a="92udv0vg"><emu-nt>XHTMLHexCharacterReference</emu-nt></emu-rhs>
+    <emu-rhs a="-rh6rgss"><emu-nt>XHTMLNamedCharacterReference</emu-nt></emu-rhs>
+</emu-production>
+<emu-production name="HTMLDecimalCharacterReference" type="lexical">
+    <emu-nt>HTMLDecimalCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="fo85v5rn">
+        <emu-t>&amp;</emu-t>
+        <emu-t>#</emu-t>
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>
+        <emu-gmod>but only if MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt> ≦ 0x10FFFF</emu-gmod>
+        <emu-t>;</emu-t>
+    </emu-rhs>
+</emu-production>
+<emu-production name="HTMLHexCharacterReference" type="lexical">
+    <emu-nt>HTMLHexCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="d9cf0zze">
+        <emu-t>&amp;</emu-t>
+        <emu-t>#</emu-t>
+        <emu-t>x</emu-t>
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-HexDigits">HexDigits</a></emu-nt>
+        <emu-gmod>but only if MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-HexDigits">HexDigits</a></emu-nt> ≦ 0x10FFFF</emu-gmod>
+        <emu-t>;</emu-t>
+    </emu-rhs>
+</emu-production>
+<emu-production name="HTMLNamedCharacterReference" type="lexical">
+    <emu-nt>HTMLNamedCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="er91pyag">
+        <emu-t>&amp;</emu-t>
+        <emu-nt>HTMLNamedCharacterReferenceName</emu-nt>
+        <emu-t>;</emu-t>
+    </emu-rhs>
+</emu-production>
+<emu-production name="HTMLNamedCharacterReferenceName" type="lexical">
+    <emu-nt>HTMLNamedCharacterReferenceName</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="kmiuecgl"><emu-gprose>An implementations-defined list of names</emu-gprose></emu-rhs>
+</emu-production>
+</emu-grammar>
+
+      <emu-note><span class="note">Note 2</span><div class="note-contents"> 
+        <p>We recommend an implementation to choose the list from either the HTML4 standard or the living HTML standard:</p>
+        <ul>
+        <li>
+        The HTML4 standard defined <a href="https://www.w3.org/TR/1999/REC-html401-19991224/sgml/entities.html">a list of 252 character entity references</a> . 
+        </li>
+        <li>
+        The living HTML standard defined <a href="https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references">a list of 2231 named character references</a> since the HTML5 standard. It also claimed that <a href="https://github.com/whatwg/html/blob/main/FAQ.md#html-should-add-more-named-character-references">this list is static and will not be expanded or changed in the future</a> to reduce support burden for languages such as JSX.
+        </li>
+        </ul>
+        <p>
+          As the time of writing, both Babel and TypeScript supports only the 252 names defined in the HTML4 standard.
+        </p>
+      </div></emu-note>
+    </emu-clause>
+
+
+    <emu-clause id="sec-jsx-JSXString">
+      <h1><span class="secnum">1.5.3</span> JSX String Definition</h1>
+      <h2>Syntax</h2>
+      <emu-grammar><emu-production name="JSXString">
+    <emu-nt>JSXString</emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="a4zlsky9"><emu-nt id="_ref_59"><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a></emu-nt></emu-rhs>
+    <emu-rhs a="mk2bi2rf"><emu-nt id="_ref_60"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a></emu-nt></emu-rhs>
+    <emu-rhs a="iwpkswln"><emu-nt id="_ref_61"><a href="#prod-JSXText">JSXText</a></emu-nt></emu-rhs>
+</emu-production>
+</emu-grammar>
+
+      <emu-clause type="sdo" id="sec-jsx-JSXString-SV">
+        <h1><span class="secnum">1.5.3.1</span> Static Semantics: SV</h1>
+        <p>An implementation may convert <emu-nt>JSXString</emu-nt> into a ECMAScript String value. In order to do this, JSX extends the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operation</a></emu-xref> <a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a> to <emu-nt>JSXStringCharacter</emu-nt>:</p> 
+        <ul>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar><emu-production name="JSXStringCharacter" type="lexical" collapsed="" class=" inline">
+    <emu-nt>JSXStringCharacter</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="v3ewaosn"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt></emu-rhs>
+</emu-production>
+</emu-grammar> is the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code point matched by <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt>.
+            </ins>
+          </li>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar><emu-production name="HTMLDecimalCharacterReference" type="lexical" collapsed="" class=" inline">
+    <emu-nt>HTMLDecimalCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="gdsompvk">
+        <emu-t>&amp;</emu-t>
+        <emu-t>#</emu-t>
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>
+        <emu-t>;</emu-t>
+    </emu-rhs>
+</emu-production>
+</emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>
+            </ins>
+          </li>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar><emu-production name="HTMLHexCharacterReference" type="lexical" collapsed="" class=" inline">
+    <emu-nt>HTMLHexCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="e4w_lnw7">
+        <emu-t>&amp;</emu-t>
+        <emu-t>#</emu-t>
+        <emu-t>x</emu-t>
+        <emu-nt><a href="https://tc39.es/ecma262/#prod-HexDigits">HexDigits</a></emu-nt>
+        <emu-t>;</emu-t>
+    </emu-rhs>
+</emu-production>
+</emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the MV of <emu-nt><a href="https://tc39.es/ecma262/#prod-HexDigits">HexDigits</a></emu-nt>
+            </ins>
+          </li>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar><emu-production name="HTMLNamedCharacterReference" type="lexical" collapsed="" class=" inline">
+    <emu-nt>HTMLNamedCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="er91pyag">
+        <emu-t>&amp;</emu-t>
+        <emu-nt>HTMLNamedCharacterReferenceName</emu-nt>
+        <emu-t>;</emu-t>
+    </emu-rhs>
+</emu-production>
+</emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code points matched by <emu-nt>HTMLNamedCharacterReferenceName</emu-nt> according the implementation-defined list of names.
+            </ins>
+          </li>
+        </ul>
+
+        <p>The exact approach to fulfill the extended sematics is <a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a>.</p>
+        <emu-note><span class="note">Note</span><div class="note-contents">
+            For example, at the time of writing, Babel implemented this in its <a href="https://github.com/babel/babel/blob/main/packages/babel-parser/src/plugins/jsx/index.js">JSX parser</a>, while TypeScript implemented it via a <a href="https://github.com/microsoft/TypeScript/blob/main/src/compiler/transformers/jsx.ts">JSX transformer</a>.
+        </div></emu-note>
+      </emu-clause>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 

--- a/spec.emu
+++ b/spec.emu
@@ -174,7 +174,7 @@ render(dropdown);
         JSXFragment
         `{` JSXChildExpression? `}`
 
-      JSXText :
+      JSXText ::
         JSXTextCharacter JSXText?
 
       JSXTextCharacter ::
@@ -194,7 +194,7 @@ render(dropdown);
     <emu-clause id="sec-jsx-string-characters">
       <h1>JSX String Characters</h1>
 
-      <p>Historically, string characters within |JSXAttributeValue| and |JSXText| are extended to allow the presence of <emu-xref href="#sec-HTMLCharacterReference">HTML character references</emu-xref> to make copy-pasting between HTML and JSX easier. We may revisit this decision in the future.</p>
+      <p>Historically, string characters within |JSXAttributeValue| and |JSXText| are extended to allow the presence of <emu-xref href="#sec-HTMLCharacterReference">HTML character references</emu-xref> to make copy-pasting between HTML and JSX easier, at the cost of not supporting `\\` |EscapeSequence| of ECMAScript's |StringLiteral|. We may revisit this decision in the future.</p>
       
       <h2>Syntax</h2>
 
@@ -207,16 +207,16 @@ render(dropdown);
     <emu-clause id="sec-HTMLCharacterReference">
       <h1>HTML Character References</h1>
       <emu-note>
-      <p>HTML character references are defined in the <a href="https://html.spec.whatwg.org/multipage/syntax.html#character-references">HTML standard</a>.</p>
+      <p>The grammars here followed <a href="https://html.spec.whatwg.org/multipage/syntax.html#character-references">the living HTML standard</a>.</p>
       </emu-note>
 
       <h2>Syntax</h2>
 
       <emu-grammar>
         HTMLCharacterReference::
-          XHTMLDecimalCharacterReference
-          XHTMLHexCharacterReference
-          XHTMLNamedCharacterReference
+          HTMLDecimalCharacterReference
+          HTMLHexCharacterReference
+          HTMLNamedCharacterReference
 
         HTMLDecimalCharacterReference::
           `&` `#` DecimalDigits [> but only if MV of |DecimalDigits| ≦ 0x10FFFF] `;`
@@ -228,21 +228,15 @@ render(dropdown);
           `&` HTMLNamedCharacterReferenceName `;`
 
         HTMLNamedCharacterReferenceName::
-          > An implementations-defined list of names
+          > List of 252 character entity references defined in HTML4 standard
       </emu-grammar>
 
       <emu-note> 
-        <p>We recommend an implementation to choose the list from either the HTML4 standard or the living HTML standard:</p>
-        <ul>
-        <li>
-        The HTML4 standard defined <a href="https://www.w3.org/TR/1999/REC-html401-19991224/sgml/entities.html">a list of 252 character entity references</a> . 
-        </li>
-        <li>
-        The living HTML standard defined <a href="https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references">a list of 2231 named character references</a> since the HTML5 standard. It also claimed that <a href="https://github.com/whatwg/html/blob/main/FAQ.md#html-should-add-more-named-character-references">this list is static and will not be expanded or changed in the future</a> to reduce support burden for languages such as JSX.
-        </li>
-        </ul>
         <p>
-          As the time of writing, both Babel and TypeScript supports only the 252 names defined in the HTML4 standard.
+          This means that the later expansion of this list to <a href="https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references">2231 named character references</a> since HTML5 are intentionally <i>excluded</i> from the support.
+        </p>
+        <p>
+          The list of 252 character entity references defined in HTML4 standard can be found <a href="https://www.w3.org/TR/1999/REC-html401-19991224/sgml/entities.html">at here</a>.
         </p>
       </emu-note>
     </emu-clause>
@@ -261,28 +255,22 @@ render(dropdown);
       <emu-clause type="sdo" id="sec-jsx-JSXString-SV">
         <h1>Static Semantics: SV</h1>
         <p>An implementation may convert |JSXString| into a ECMAScript String value. In order to do this, JSX extends the syntax-directed operation <a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a> to |JSXStringCharacter|:</p> 
-        <ul>
-          <li>
-            <ins class="block">
-              The SV of <emu-grammar> JSXStringCharacter :: SourceCharacter </emu-grammar> is the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code point matched by |SourceCharacter|.
-            </ins>
-          </li>
-          <li>
-            <ins class="block">
-              The SV of <emu-grammar> HTMLDecimalCharacterReference:: `&` `#` DecimalDigits `;` </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the MV of |DecimalDigits|
-            </ins>
-          </li>
-          <li>
-            <ins class="block">
-              The SV of <emu-grammar>HTMLHexCharacterReference:: `&` `#` `x` HexDigits `;` </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the MV of |HexDigits|
-            </ins>
-          </li>
-          <li>
-            <ins class="block">
-              The SV of <emu-grammar>HTMLNamedCharacterReference:: `&` HTMLNamedCharacterReferenceName `;` </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code points matched by |HTMLNamedCharacterReferenceName| according the implementation-defined list of names.
-            </ins>
-          </li>
-        </ul>
+        <ins class="block">
+          <ul>
+            <li>
+                The SV of <emu-grammar> JSXStringCharacter :: SourceCharacter </emu-grammar> is the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code point matched by |SourceCharacter|.
+            </li>
+            <li>
+                The SV of <emu-grammar> HTMLDecimalCharacterReference:: `&` `#` DecimalDigits `;` </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the MV of |DecimalDigits|
+            </li>
+            <li>
+                The SV of <emu-grammar>HTMLHexCharacterReference:: `&` `#` `x` HexDigits `;` </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the MV of |HexDigits|
+            </li>
+            <li>
+                The SV of <emu-grammar>HTMLNamedCharacterReference:: `&` HTMLNamedCharacterReferenceName `;` </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code points matched by |HTMLNamedCharacterReferenceName| according the implementation-defined list of names.
+            </li>
+          </ul>
+        </ins>
 
         <p>The exact approach to fulfill the extended sematics is <a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a>.</p>
         <emu-note>

--- a/spec.emu
+++ b/spec.emu
@@ -43,7 +43,7 @@ render(dropdown);
 </emu-intro>
 
 
-<emu-clause id="sec-jsx-grammar">
+<emu-clause id="sec-jsx">
   <h1>JSX Definition</h1>
 
   <emu-clause id="sec-jsx-PrimaryExpression">
@@ -145,17 +145,18 @@ render(dropdown);
         JSXElement
         JSXFragment
 
-      JSXDoubleStringCharacters :
+      JSXDoubleStringCharacters ::
         JSXDoubleStringCharacter JSXDoubleStringCharacters?
 
-      JSXDoubleStringCharacter :
-        SourceCharacter but not `"`
+      JSXDoubleStringCharacter ::
+        JSXStringCharacter but not `"`
 
-      JSXSingleStringCharacters :
+      JSXSingleStringCharacters ::
         JSXSingleStringCharacter JSXSingleStringCharacters?
 
-      JSXSingleStringCharacter :
-        SourceCharacter but not `'`
+      JSXSingleStringCharacter ::
+        JSXStringCharacter but not `'`
+
     </emu-grammar>
   </emu-clause>
 
@@ -176,14 +177,119 @@ render(dropdown);
       JSXText :
         JSXTextCharacter JSXText?
 
-      JSXTextCharacter :
-        SourceCharacter but not one of `{` or `<` or `>` or `}`
+      JSXTextCharacter ::
+        JSXStringCharacter but not one of `{` or `<` or `>` or `}`
 
       JSXChildExpression :
         AssignmentExpression
         `...` AssignmentExpression
 
     </emu-grammar>
+  </emu-clause>
+
+  <emu-clause id="sec-jsx-string">
+    <h1>JSX Strings</h1>
+
+
+    <emu-clause id="sec-jsx-string-characters">
+      <h1>JSX String Characters</h1>
+
+      <p>Historically, string characters within |JSXAttributeValue| and |JSXText| are extended to allow the presence of <emu-xref href="#sec-HTMLCharacterReference">HTML character references</emu-xref> to make copy-pasting between HTML and JSX easier. We may revisit this decision in the future.</p>
+      
+      <h2>Syntax</h2>
+
+      <emu-grammar>
+        JSXStringCharacter::
+          SourceCharacter but not one of HTMLCharacterReference
+      </emu-grammar>
+    </emu-clause>
+
+    <emu-clause id="sec-HTMLCharacterReference">
+      <h1>HTML Character References</h1>
+      <emu-note>
+      <p>HTML character references are defined in the <a href="https://html.spec.whatwg.org/multipage/syntax.html#character-references">HTML standard</a>.</p>
+      </emu-note>
+
+      <h2>Syntax</h2>
+
+      <emu-grammar>
+        HTMLCharacterReference::
+          XHTMLDecimalCharacterReference
+          XHTMLHexCharacterReference
+          XHTMLNamedCharacterReference
+
+        HTMLDecimalCharacterReference::
+          `&` `#` DecimalDigits [> but only if MV of |DecimalDigits| ≦ 0x10FFFF] `;`
+
+        HTMLHexCharacterReference::
+          `&` `#` `x` HexDigits [> but only if MV of |HexDigits| ≦ 0x10FFFF] `;`
+
+        HTMLNamedCharacterReference::
+          `&` HTMLNamedCharacterReferenceName `;`
+
+        HTMLNamedCharacterReferenceName::
+          > An implementations-defined list of names
+      </emu-grammar>
+
+      <emu-note> 
+        <p>We recommend an implementation to choose the list from either the HTML4 standard or the living HTML standard:</p>
+        <ul>
+        <li>
+        The HTML4 standard defined <a href="https://www.w3.org/TR/1999/REC-html401-19991224/sgml/entities.html">a list of 252 character entity references</a> . 
+        </li>
+        <li>
+        The living HTML standard defined <a href="https://html.spec.whatwg.org/multipage/named-characters.html#named-character-references">a list of 2231 named character references</a> since the HTML5 standard. It also claimed that <a href="https://github.com/whatwg/html/blob/main/FAQ.md#html-should-add-more-named-character-references">this list is static and will not be expanded or changed in the future</a> to reduce support burden for languages such as JSX.
+        </li>
+        </ul>
+        <p>
+          As the time of writing, both Babel and TypeScript supports only the 252 names defined in the HTML4 standard.
+        </p>
+      </emu-note>
+    </emu-clause>
+
+
+    <emu-clause id="sec-jsx-JSXString">
+      <h1>JSX String Definition</h1>
+      <h2>Syntax</h2>
+      <emu-grammar>
+        JSXString :
+          JSXDoubleStringCharacters
+          JSXSingleStringCharacters
+          JSXText
+      </emu-grammar>
+
+      <emu-clause type="sdo" id="sec-jsx-JSXString-SV">
+        <h1>Static Semantics: SV</h1>
+        <p>An implementation may convert |JSXString| into a ECMAScript String value. In order to do this, JSX extends the syntax-directed operation <a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a> to |JSXStringCharacter|:</p> 
+        <ul>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar> JSXStringCharacter :: SourceCharacter </emu-grammar> is the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code point matched by |SourceCharacter|.
+            </ins>
+          </li>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar> HTMLDecimalCharacterReference:: `&` `#` DecimalDigits `;` </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the MV of |DecimalDigits|
+            </ins>
+          </li>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar>HTMLHexCharacterReference:: `&` `#` `x` HexDigits `;` </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the MV of |HexDigits|
+            </ins>
+          </li>
+          <li>
+            <ins class="block">
+              The SV of <emu-grammar>HTMLNamedCharacterReference:: `&` HTMLNamedCharacterReferenceName `;` </emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code points matched by |HTMLNamedCharacterReferenceName| according the implementation-defined list of names.
+            </ins>
+          </li>
+        </ul>
+
+        <p>The exact approach to fulfill the extended sematics is <a href="https://tc39.es/ecma262/#implementation-defined">implementation-defined</a>.</p>
+        <emu-note>
+            For example, at the time of writing, Babel implemented this in its <a href="https://github.com/babel/babel/blob/main/packages/babel-parser/src/plugins/jsx/index.js">JSX parser</a>, while TypeScript implemented it via a <a href="https://github.com/microsoft/TypeScript/blob/main/src/compiler/transformers/jsx.ts">JSX transformer</a>.
+        </emu-note>
+      </emu-clause>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 


### PR DESCRIPTION
## Summary

Let's be faithful to the de-facto and document the HTML entity behaviors to the spec. Note that this is not about whether we should "drop this semantics or not", but about documenting the current behaviors that everyone has been living with for years.

### The Proposed Normative Change

I'm not aware of any practices specifying such transpiler/transform semantics in ECMA-262 so this is a really interesting attempt 🙂 So I ended up extending `Static Semantics: SV` which is the smartest way I can find to hack the semantics into the ECMA-262 spec. I think this should work and should be accurate enough. I'm curious on how implementors think about it though.

<del>I also intentionally left the set of supported HTML entities implementation-defined to allow either HTML4 or HTML5 set. This may be seen as a breaking change in some regard and **this is open to discuss here**. </del> We've reached consensus that only HTML4 entities are allowed.

This commit also close #133 by using `::` for characters which are supposed to be lexical grammars.

Close #126
Close #4

## Test Plan

open `index.html` and proof-read the spec ;)

### Preview at my fork <https://huxpro.github.io/jsx>