### PR TITLE
Disallow `<` after a JSX  element

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -52,7 +52,7 @@ render(dropdown);
 
     <h2>Syntax</h2>
     <emu-grammar>
-      PrimaryExpression ::
+      PrimaryExpression :
         <ins>JSXElementOrFragment `<`</ins>
         <ins>JSXElementOrFragment</ins>
     </emu-grammar>

--- a/spec.emu
+++ b/spec.emu
@@ -52,10 +52,30 @@ render(dropdown);
 
     <h2>Syntax</h2>
     <emu-grammar>
-      PrimaryExpression :
-        <ins>JSXElement</ins>
-        <ins>JSXFragment</ins>
+      PrimaryExpression ::
+        <ins>JSXElementOrFragment `<`</ins>
+        <ins>JSXElementOrFragment</ins>
     </emu-grammar>
+
+    <emu-clause type="sdo" id="sec-jsx-PrimaryExpression-early-errors">
+      <h1>Static Semantics: Early Errors</h1>
+      <emu-grammar>
+        PrimaryExpression :: JSXElementOrFragment `<`
+      </emu-grammar>
+      <ul>
+        <li>It is a SyntaxError if any source text is matched by this production.</li>
+      </ul>
+      <emu-note>
+        This Early Error prevents users from accidentally writing two adjacent JSX elements without wrapping them in a fragment:
+          <pre><code class="language-jsx">
+// Invalid
+var elts = &lt;a&gt;&lt;/a&gt;&lt;b&gt;&lt;/b&gt;
+
+// Valid
+var elts = &lt;&gt;&lt;a&gt;&lt;/a&gt;&lt;b&gt;&lt;/b&gt;&lt;/&gt;
+  </code></pre>
+      </emu-note>
+    </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-jsx-elements">
@@ -63,6 +83,10 @@ render(dropdown);
     <h2>Syntax</h2>
 
     <emu-grammar type="definition">
+      JSXElementOrFragment ::
+        JSXElement
+        JSXFragment
+
       JSXElement :
         JSXSelfClosingElement
         JSXOpeningElement JSXChildren? JSXClosingElement


### PR DESCRIPTION
Fixes #120.

This was quite hard to specify:
- I initially tried to add an early error to `RelationalExpression` saying something like "It is a SyntaxError if the left side of the expression recursively contains a `JSXElementOrFragment` as its right-most descendent.", but it would have required writing some custom sdo for every production that can derive a `JSXElementOrFragment` as a child of `RelationalExpression`.
- The spec explicitly ignores lookaheads in static semantics, so I wanted to avoid doing it.

> :warning: Almost all the tools already implement this error, but it would be a breaking change for the Flow type checker.