### PR TITLE
Improve spec text from #138

### DIFF
--- a/index.html
+++ b/index.html
@@ -1148,8 +1148,8 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
-let sdoMap = JSON.parse(`{"prod-KCDyML_C":{"Early":{"clause":"2","ids":["prod-p4aAXPL4"]}}}`);
-let biblio = JSON.parse(`{"refsByClause":{"sec-jsx-PrimaryExpression":["_ref_0","_ref_1"],"sec-jsx-elements":["_ref_2","_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_9","_ref_10","_ref_11","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22"],"sec-jsx-attributes":["_ref_23","_ref_24","_ref_25","_ref_26","_ref_27","_ref_28","_ref_29","_ref_30","_ref_31","_ref_32","_ref_33","_ref_34","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39"],"sec-jsx-children":["_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45","_ref_46","_ref_47"],"sec-early-errors":["_ref_48","_ref_49","_ref_50","_ref_51","_ref_52","_ref_53","_ref_54"]},"entries":[{"type":"clause","id":"sec-rationale","titleHTML":"Rationale","number":""},{"type":"clause","id":"sec-intro","titleHTML":"Introduction","number":""},{"type":"clause","id":"sec-jsx-PrimaryExpression","titleHTML":"Modified Productions","number":"1.1"},{"type":"production","id":"prod-JSXElement","name":"JSXElement","referencingIds":["_ref_0","_ref_34","_ref_43"]},{"type":"production","id":"prod-JSXSelfClosingElement","name":"JSXSelfClosingElement","referencingIds":["_ref_2"]},{"type":"production","id":"prod-JSXOpeningElement","name":"JSXOpeningElement","referencingIds":["_ref_3","_ref_48","_ref_52"]},{"type":"production","id":"prod-JSXClosingElement","name":"JSXClosingElement","referencingIds":["_ref_5","_ref_50","_ref_54"]},{"type":"production","id":"prod-JSXFragment","name":"JSXFragment","referencingIds":["_ref_1","_ref_35","_ref_44"]},{"type":"production","id":"prod-JSXElementName","name":"JSXElementName","referencingIds":["_ref_6","_ref_8","_ref_10","_ref_51","_ref_53"]},{"type":"production","id":"prod-JSXIdentifier","name":"JSXIdentifier","referencingIds":["_ref_12","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_22","_ref_29"]},{"type":"production","id":"prod-JSXNamespacedName","name":"JSXNamespacedName","referencingIds":["_ref_13","_ref_30"]},{"type":"production","id":"prod-JSXMemberExpression","name":"JSXMemberExpression","referencingIds":["_ref_14","_ref_21"]},{"type":"clause","id":"sec-jsx-elements","titleHTML":"JSX Elements","number":"1.2"},{"type":"production","id":"prod-JSXAttributes","name":"JSXAttributes","referencingIds":["_ref_7","_ref_9","_ref_24","_ref_26"]},{"type":"production","id":"prod-JSXSpreadAttribute","name":"JSXSpreadAttribute","referencingIds":["_ref_23"]},{"type":"production","id":"prod-JSXAttribute","name":"JSXAttribute","referencingIds":["_ref_25"]},{"type":"production","id":"prod-JSXAttributeName","name":"JSXAttributeName","referencingIds":["_ref_27"]},{"type":"production","id":"prod-JSXAttributeInitializer","name":"JSXAttributeInitializer","referencingIds":["_ref_28"]},{"type":"production","id":"prod-JSXAttributeValue","name":"JSXAttributeValue","referencingIds":["_ref_31"]},{"type":"production","id":"prod-JSXDoubleStringCharacters","name":"JSXDoubleStringCharacters","referencingIds":["_ref_32","_ref_37"]},{"type":"production","id":"prod-JSXDoubleStringCharacter","name":"JSXDoubleStringCharacter","referencingIds":["_ref_36"]},{"type":"production","id":"prod-JSXSingleStringCharacters","name":"JSXSingleStringCharacters","referencingIds":["_ref_33","_ref_39"]},{"type":"production","id":"prod-JSXSingleStringCharacter","name":"JSXSingleStringCharacter","referencingIds":["_ref_38"]},{"type":"clause","id":"sec-jsx-attributes","titleHTML":"JSX Attributes","number":"1.3"},{"type":"production","id":"prod-JSXChildren","name":"JSXChildren","referencingIds":["_ref_4","_ref_11","_ref_41","_ref_49"]},{"type":"production","id":"prod-JSXChild","name":"JSXChild","referencingIds":["_ref_40"]},{"type":"production","id":"prod-JSXText","name":"JSXText","referencingIds":["_ref_42","_ref_47"]},{"type":"production","id":"prod-JSXTextCharacter","name":"JSXTextCharacter","referencingIds":["_ref_46"]},{"type":"production","id":"prod-JSXChildExpression","name":"JSXChildExpression","referencingIds":["_ref_45"]},{"type":"clause","id":"sec-jsx-children","titleHTML":"JSX Children","number":"1.4"},{"type":"clause","id":"sec-jsx-grammar","titleHTML":"JSX Definition","number":"1"},{"type":"clause","id":"sec-early-errors","titleHTML":"Static Semantics: Early Errors","number":"2"},{"type":"clause","id":"sec-why-not-template-literals","titleHTML":"Why not Template Literals?","number":"A"},{"type":"clause","id":"sec-why-not-JXON","titleHTML":"Why not JXON?","number":"B"},{"type":"clause","id":"sec-prior-art","titleHTML":"Prior Art","number":"C"},{"type":"clause","id":"sec-license","titleHTML":"License","number":"D"}]}`);
+let sdoMap = JSON.parse(`{"prod-KCDyML_C":{"Early":{"clause":"1.2.1","ids":["prod-p4aAXPL4"]}}}`);
+let biblio = JSON.parse(`{"refsByClause":{"sec-jsx-PrimaryExpression":["_ref_0","_ref_1"],"sec-jsx-elements":["_ref_2","_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_9","_ref_10","_ref_11","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23"],"sec-jsx-elements-early-errors":["_ref_24","_ref_25","_ref_26","_ref_27","_ref_28","_ref_29","_ref_30"],"sec-jsx-attributes":["_ref_31","_ref_32","_ref_33","_ref_34","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45","_ref_46","_ref_47"],"sec-jsx-children":["_ref_48","_ref_49","_ref_50","_ref_51","_ref_52","_ref_53","_ref_54","_ref_55"]},"entries":[{"type":"clause","id":"sec-rationale","titleHTML":"Rationale","number":""},{"type":"clause","id":"sec-intro","titleHTML":"Introduction","number":""},{"type":"clause","id":"sec-jsx-PrimaryExpression","titleHTML":"Modified Productions","number":"1.1"},{"type":"production","id":"prod-JSXElement","name":"JSXElement","referencingIds":["_ref_0","_ref_42","_ref_51"]},{"type":"production","id":"prod-JSXSelfClosingElement","name":"JSXSelfClosingElement","referencingIds":["_ref_2"]},{"type":"production","id":"prod-JSXOpeningElement","name":"JSXOpeningElement","referencingIds":["_ref_3","_ref_24","_ref_28"]},{"type":"production","id":"prod-JSXClosingElement","name":"JSXClosingElement","referencingIds":["_ref_5","_ref_26","_ref_30"]},{"type":"production","id":"prod-JSXFragment","name":"JSXFragment","referencingIds":["_ref_1","_ref_43","_ref_52"]},{"type":"production","id":"prod-JSXElementName","name":"JSXElementName","referencingIds":["_ref_6","_ref_8","_ref_10","_ref_27","_ref_29"]},{"type":"production","id":"prod-JSXIdentifier","name":"JSXIdentifier","referencingIds":["_ref_12","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_23","_ref_37"]},{"type":"production","id":"prod-JSXNamespacedName","name":"JSXNamespacedName","referencingIds":["_ref_13","_ref_38"]},{"type":"production","id":"prod-JSXMemberExpression","name":"JSXMemberExpression","referencingIds":["_ref_14","_ref_22"]},{"type":"clause","id":"sec-jsx-elements-early-errors","titleHTML":"Static Semantics: Early Errors","number":"1.2.1"},{"type":"clause","id":"sec-jsx-elements","titleHTML":"JSX Elements","number":"1.2"},{"type":"production","id":"prod-JSXAttributes","name":"JSXAttributes","referencingIds":["_ref_7","_ref_9","_ref_32","_ref_34"]},{"type":"production","id":"prod-JSXSpreadAttribute","name":"JSXSpreadAttribute","referencingIds":["_ref_31"]},{"type":"production","id":"prod-JSXAttribute","name":"JSXAttribute","referencingIds":["_ref_33"]},{"type":"production","id":"prod-JSXAttributeName","name":"JSXAttributeName","referencingIds":["_ref_35"]},{"type":"production","id":"prod-JSXAttributeInitializer","name":"JSXAttributeInitializer","referencingIds":["_ref_36"]},{"type":"production","id":"prod-JSXAttributeValue","name":"JSXAttributeValue","referencingIds":["_ref_39"]},{"type":"production","id":"prod-JSXDoubleStringCharacters","name":"JSXDoubleStringCharacters","referencingIds":["_ref_40","_ref_45"]},{"type":"production","id":"prod-JSXDoubleStringCharacter","name":"JSXDoubleStringCharacter","referencingIds":["_ref_44"]},{"type":"production","id":"prod-JSXSingleStringCharacters","name":"JSXSingleStringCharacters","referencingIds":["_ref_41","_ref_47"]},{"type":"production","id":"prod-JSXSingleStringCharacter","name":"JSXSingleStringCharacter","referencingIds":["_ref_46"]},{"type":"clause","id":"sec-jsx-attributes","titleHTML":"JSX Attributes","number":"1.3"},{"type":"production","id":"prod-JSXChildren","name":"JSXChildren","referencingIds":["_ref_4","_ref_11","_ref_25","_ref_49"]},{"type":"production","id":"prod-JSXChild","name":"JSXChild","referencingIds":["_ref_48"]},{"type":"production","id":"prod-JSXText","name":"JSXText","referencingIds":["_ref_50","_ref_55"]},{"type":"production","id":"prod-JSXTextCharacter","name":"JSXTextCharacter","referencingIds":["_ref_54"]},{"type":"production","id":"prod-JSXChildExpression","name":"JSXChildExpression","referencingIds":["_ref_53"]},{"type":"clause","id":"sec-jsx-children","titleHTML":"JSX Children","number":"1.4"},{"type":"clause","id":"sec-jsx-grammar","titleHTML":"JSX Definition","number":"1"},{"type":"clause","id":"sec-why-not-template-literals","titleHTML":"Why not Template Literals?","number":"A"},{"type":"clause","id":"sec-why-not-JXON","titleHTML":"Why not JXON?","number":"B"},{"type":"clause","id":"sec-prior-art","titleHTML":"Prior Art","number":"C"},{"type":"clause","id":"sec-license","titleHTML":"License","number":"D"}]}`);
 ;let usesMultipage = false</script><style>body {
   display: flex;
   font-size: 18px;
@@ -2414,7 +2414,7 @@ li.menu-search-result-term:before {
 </ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
       <title>Menu</title>
       <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
-    </svg></div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intro" title="Introduction">Introduction</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-rationale" title="Rationale">Rationale</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-grammar" title="JSX Definition"><span class="secnum">1</span> JSX Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-PrimaryExpression" title="Modified Productions"><span class="secnum">1.1</span> Modified Productions</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-elements" title="JSX Elements"><span class="secnum">1.2</span> JSX Elements</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-attributes" title="JSX Attributes"><span class="secnum">1.3</span> JSX Attributes</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-children" title="JSX Children"><span class="secnum">1.4</span> JSX Children</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-early-errors" title="Static Semantics: Early Errors"><span class="secnum">2</span> SS: Early Errors</a></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-template-literals" title="Why not Template Literals?"><span class="secnum">A</span> Why not Template Literals?</a></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-JXON" title="Why not JXON?"><span class="secnum">B</span> Why not JXON?</a></li><li><span class="item-toggle-none"></span><a href="#sec-prior-art" title="Prior Art"><span class="secnum">C</span> Prior Art</a></li><li><span class="item-toggle-none"></span><a href="#sec-license" title="License"><span class="secnum">D</span> License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Draft / February 25, 2022</h1><h1 class="title">JSX</h1>
+    </svg></div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intro" title="Introduction">Introduction</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-rationale" title="Rationale">Rationale</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-grammar" title="JSX Definition"><span class="secnum">1</span> JSX Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-PrimaryExpression" title="Modified Productions"><span class="secnum">1.1</span> Modified Productions</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-elements" title="JSX Elements"><span class="secnum">1.2</span> JSX Elements</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-elements-early-errors" title="Static Semantics: Early Errors"><span class="secnum">1.2.1</span> SS: Early Errors</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-attributes" title="JSX Attributes"><span class="secnum">1.3</span> JSX Attributes</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-children" title="JSX Children"><span class="secnum">1.4</span> JSX Children</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-template-literals" title="Why not Template Literals?"><span class="secnum">A</span> Why not Template Literals?</a></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-JXON" title="Why not JXON?"><span class="secnum">B</span> Why not JXON?</a></li><li><span class="item-toggle-none"></span><a href="#sec-prior-art" title="Prior Art"><span class="secnum">C</span> Prior Art</a></li><li><span class="item-toggle-none"></span><a href="#sec-license" title="License"><span class="secnum">D</span> License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Draft / February 28, 2022</h1><h1 class="title">JSX</h1>
 
 <emu-intro id="sec-intro">
   <h1>Introduction</h1>
@@ -2529,29 +2529,45 @@ li.menu-search-result-term:before {
 </emu-grammar>
 
     <emu-note><span class="note">Note</span><div class="note-contents">
-      JSXIdentifier is different from Identifier, which means in the context of <emu-nt params="+await"><a href="https://tc39.es/ecma262/#prod-grammar-notation-Identifier">Identifier</a><emu-mods><emu-params>[+await]</emu-params></emu-mods></emu-nt>, you can still use <code>&lt;await /&gt;</code> as a JSX tag.
+      The grammar of <emu-nt id="_ref_17"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt> is not parameterized the same way <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-Identifier">Identifier</a></emu-nt> is. This means that <code>&lt;await /&gt;</code> is still a valid production when "[await]" appears during the derivation.
     </div></emu-note>
 
     <emu-grammar type="definition"><emu-production name="JSXNamespacedName" id="prod-JSXNamespacedName">
     <emu-nt><a href="#prod-JSXNamespacedName">JSXNamespacedName</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="mhf25omg">
-        <emu-nt id="_ref_17"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
-        <emu-t>:</emu-t>
         <emu-nt id="_ref_18"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
+        <emu-t>:</emu-t>
+        <emu-nt id="_ref_19"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXMemberExpression" id="prod-JSXMemberExpression">
     <emu-nt><a href="#prod-JSXMemberExpression">JSXMemberExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="si4-esnv">
-        <emu-nt id="_ref_19"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
-        <emu-t>.</emu-t>
         <emu-nt id="_ref_20"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
+        <emu-t>.</emu-t>
+        <emu-nt id="_ref_21"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
     </emu-rhs>
     <emu-rhs a="y0hgepyh">
-        <emu-nt id="_ref_21"><a href="#prod-JSXMemberExpression">JSXMemberExpression</a></emu-nt>
+        <emu-nt id="_ref_22"><a href="#prod-JSXMemberExpression">JSXMemberExpression</a></emu-nt>
         <emu-t>.</emu-t>
-        <emu-nt id="_ref_22"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
+        <emu-nt id="_ref_23"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt>
     </emu-rhs>
 </emu-production>
 </emu-grammar>
+
+    <emu-clause type="sdo" id="sec-jsx-elements-early-errors">
+      <h1><span class="secnum">1.2.1</span> Static Semantics: Early Errors</h1>
+      <emu-grammar><emu-production name="JSXElement" collapsed="">
+    <emu-nt><a href="#prod-JSXElement">JSXElement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="urykrh2r" id="prod-p4aAXPL4">
+        <emu-nt id="_ref_24"><a href="#prod-JSXOpeningElement">JSXOpeningElement</a></emu-nt>
+        <emu-nt optional="" id="_ref_25"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_26"><a href="#prod-JSXClosingElement">JSXClosingElement</a></emu-nt>
+    </emu-rhs>
+</emu-production>
+</emu-grammar>
+      <ul>
+        <li>It is a Syntax Error if the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">source text matched by</a></emu-xref> the <emu-nt id="_ref_27"><a href="#prod-JSXElementName">JSXElementName</a></emu-nt> of <emu-nt id="_ref_28"><a href="#prod-JSXOpeningElement">JSXOpeningElement</a></emu-nt> does not equal to the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">source text matched by</a></emu-xref> the <emu-nt id="_ref_29"><a href="#prod-JSXElementName">JSXElementName</a></emu-nt> of <emu-nt id="_ref_30"><a href="#prod-JSXClosingElement">JSXClosingElement</a></emu-nt>.</li>
+      </ul>
+    </emu-clause>
+
   </emu-clause>
 
   <emu-clause id="sec-jsx-attributes">
@@ -2560,12 +2576,12 @@ li.menu-search-result-term:before {
 
     <emu-grammar type="definition"><emu-production name="JSXAttributes" id="prod-JSXAttributes">
     <emu-nt><a href="#prod-JSXAttributes">JSXAttributes</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="5mcgceuv">
-        <emu-nt id="_ref_23"><a href="#prod-JSXSpreadAttribute">JSXSpreadAttribute</a></emu-nt>
-        <emu-nt optional="" id="_ref_24"><a href="#prod-JSXAttributes">JSXAttributes</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_31"><a href="#prod-JSXSpreadAttribute">JSXSpreadAttribute</a></emu-nt>
+        <emu-nt optional="" id="_ref_32"><a href="#prod-JSXAttributes">JSXAttributes</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
     <emu-rhs a="dzdrzxq-">
-        <emu-nt id="_ref_25"><a href="#prod-JSXAttribute">JSXAttribute</a></emu-nt>
-        <emu-nt optional="" id="_ref_26"><a href="#prod-JSXAttributes">JSXAttributes</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_33"><a href="#prod-JSXAttribute">JSXAttribute</a></emu-nt>
+        <emu-nt optional="" id="_ref_34"><a href="#prod-JSXAttributes">JSXAttributes</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXSpreadAttribute" id="prod-JSXSpreadAttribute">
@@ -2578,29 +2594,29 @@ li.menu-search-result-term:before {
 </emu-production>
 <emu-production name="JSXAttribute" id="prod-JSXAttribute">
     <emu-nt><a href="#prod-JSXAttribute">JSXAttribute</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="tveyz-zf">
-        <emu-nt id="_ref_27"><a href="#prod-JSXAttributeName">JSXAttributeName</a></emu-nt>
-        <emu-nt optional="" id="_ref_28"><a href="#prod-JSXAttributeInitializer">JSXAttributeInitializer</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_35"><a href="#prod-JSXAttributeName">JSXAttributeName</a></emu-nt>
+        <emu-nt optional="" id="_ref_36"><a href="#prod-JSXAttributeInitializer">JSXAttributeInitializer</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXAttributeName" id="prod-JSXAttributeName">
-    <emu-nt><a href="#prod-JSXAttributeName">JSXAttributeName</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ehd8jr3p"><emu-nt id="_ref_29"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt></emu-rhs>
-    <emu-rhs a="xmeipvkx"><emu-nt id="_ref_30"><a href="#prod-JSXNamespacedName">JSXNamespacedName</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-JSXAttributeName">JSXAttributeName</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ehd8jr3p"><emu-nt id="_ref_37"><a href="#prod-JSXIdentifier">JSXIdentifier</a></emu-nt></emu-rhs>
+    <emu-rhs a="xmeipvkx"><emu-nt id="_ref_38"><a href="#prod-JSXNamespacedName">JSXNamespacedName</a></emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="JSXAttributeInitializer" id="prod-JSXAttributeInitializer">
     <emu-nt><a href="#prod-JSXAttributeInitializer">JSXAttributeInitializer</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="sfj32tqz">
         <emu-t>=</emu-t>
-        <emu-nt id="_ref_31"><a href="#prod-JSXAttributeValue">JSXAttributeValue</a></emu-nt>
+        <emu-nt id="_ref_39"><a href="#prod-JSXAttributeValue">JSXAttributeValue</a></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXAttributeValue" id="prod-JSXAttributeValue">
     <emu-nt><a href="#prod-JSXAttributeValue">JSXAttributeValue</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="oyac4vtf">
         <emu-t>"</emu-t>
-        <emu-nt optional="" id="_ref_32"><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_40"><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>"</emu-t>
     </emu-rhs>
     <emu-rhs a="j6v80tpm">
         <emu-t>'</emu-t>
-        <emu-nt optional="" id="_ref_33"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_41"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>'</emu-t>
     </emu-rhs>
     <emu-rhs a="0kze3tr4">
@@ -2608,13 +2624,13 @@ li.menu-search-result-term:before {
         <emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
-    <emu-rhs a="ylbqkuqt"><emu-nt id="_ref_34"><a href="#prod-JSXElement">JSXElement</a></emu-nt></emu-rhs>
-    <emu-rhs a="xcc8tnvu"><emu-nt id="_ref_35"><a href="#prod-JSXFragment">JSXFragment</a></emu-nt></emu-rhs>
+    <emu-rhs a="ylbqkuqt"><emu-nt id="_ref_42"><a href="#prod-JSXElement">JSXElement</a></emu-nt></emu-rhs>
+    <emu-rhs a="xcc8tnvu"><emu-nt id="_ref_43"><a href="#prod-JSXFragment">JSXFragment</a></emu-nt></emu-rhs>
 </emu-production>
 <emu-production name="JSXDoubleStringCharacters" id="prod-JSXDoubleStringCharacters">
     <emu-nt><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="yodnvall">
-        <emu-nt id="_ref_36"><a href="#prod-JSXDoubleStringCharacter">JSXDoubleStringCharacter</a></emu-nt>
-        <emu-nt optional="" id="_ref_37"><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_44"><a href="#prod-JSXDoubleStringCharacter">JSXDoubleStringCharacter</a></emu-nt>
+        <emu-nt optional="" id="_ref_45"><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXDoubleStringCharacter" id="prod-JSXDoubleStringCharacter">
@@ -2622,8 +2638,8 @@ li.menu-search-result-term:before {
 </emu-production>
 <emu-production name="JSXSingleStringCharacters" id="prod-JSXSingleStringCharacters">
     <emu-nt><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="xebljaxt">
-        <emu-nt id="_ref_38"><a href="#prod-JSXSingleStringCharacter">JSXSingleStringCharacter</a></emu-nt>
-        <emu-nt optional="" id="_ref_39"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_46"><a href="#prod-JSXSingleStringCharacter">JSXSingleStringCharacter</a></emu-nt>
+        <emu-nt optional="" id="_ref_47"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXSingleStringCharacter" id="prod-JSXSingleStringCharacter">
@@ -2638,24 +2654,24 @@ li.menu-search-result-term:before {
 
     <emu-grammar type="definition"><emu-production name="JSXChildren" id="prod-JSXChildren">
     <emu-nt><a href="#prod-JSXChildren">JSXChildren</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ey07n052">
-        <emu-nt id="_ref_40"><a href="#prod-JSXChild">JSXChild</a></emu-nt>
-        <emu-nt optional="" id="_ref_41"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_48"><a href="#prod-JSXChild">JSXChild</a></emu-nt>
+        <emu-nt optional="" id="_ref_49"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXChild" id="prod-JSXChild">
-    <emu-nt><a href="#prod-JSXChild">JSXChild</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="iwpkswln"><emu-nt id="_ref_42"><a href="#prod-JSXText">JSXText</a></emu-nt></emu-rhs>
-    <emu-rhs a="ylbqkuqt"><emu-nt id="_ref_43"><a href="#prod-JSXElement">JSXElement</a></emu-nt></emu-rhs>
-    <emu-rhs a="xcc8tnvu"><emu-nt id="_ref_44"><a href="#prod-JSXFragment">JSXFragment</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-JSXChild">JSXChild</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="iwpkswln"><emu-nt id="_ref_50"><a href="#prod-JSXText">JSXText</a></emu-nt></emu-rhs>
+    <emu-rhs a="ylbqkuqt"><emu-nt id="_ref_51"><a href="#prod-JSXElement">JSXElement</a></emu-nt></emu-rhs>
+    <emu-rhs a="xcc8tnvu"><emu-nt id="_ref_52"><a href="#prod-JSXFragment">JSXFragment</a></emu-nt></emu-rhs>
     <emu-rhs a="7t9rmusx">
         <emu-t>{</emu-t>
-        <emu-nt optional="" id="_ref_45"><a href="#prod-JSXChildExpression">JSXChildExpression</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_53"><a href="#prod-JSXChildExpression">JSXChildExpression</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXText" id="prod-JSXText">
     <emu-nt><a href="#prod-JSXText">JSXText</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="z5eumfmp">
-        <emu-nt id="_ref_46"><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt>
-        <emu-nt optional="" id="_ref_47"><a href="#prod-JSXText">JSXText</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_54"><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt>
+        <emu-nt optional="" id="_ref_55"><a href="#prod-JSXText">JSXText</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXTextCharacter" id="prod-JSXTextCharacter">
@@ -2670,21 +2686,6 @@ li.menu-search-result-term:before {
 </emu-production>
 </emu-grammar>
   </emu-clause>
-</emu-clause>
-
-<emu-clause type="sdo" id="sec-early-errors">
-  <h1><span class="secnum">2</span> Static Semantics: Early Errors</h1>
-  <emu-grammar><emu-production name="JSXElement" collapsed="">
-    <emu-nt><a href="#prod-JSXElement">JSXElement</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="urykrh2r" id="prod-p4aAXPL4">
-        <emu-nt id="_ref_48"><a href="#prod-JSXOpeningElement">JSXOpeningElement</a></emu-nt>
-        <emu-nt optional="" id="_ref_49"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
-        <emu-nt id="_ref_50"><a href="#prod-JSXClosingElement">JSXClosingElement</a></emu-nt>
-    </emu-rhs>
-</emu-production>
-</emu-grammar>
-  <ul>
-    <li>It is a Syntax Error if the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">source text matched by</a></emu-xref> the <emu-nt id="_ref_51"><a href="#prod-JSXElementName">JSXElementName</a></emu-nt> of <emu-nt id="_ref_52"><a href="#prod-JSXOpeningElement">JSXOpeningElement</a></emu-nt> does not equal to the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">source text matched by</a></emu-xref> the <emu-nt id="_ref_53"><a href="#prod-JSXElementName">JSXElementName</a></emu-nt> of <emu-nt id="_ref_54"><a href="#prod-JSXClosingElement">JSXClosingElement</a></emu-nt>.</li>
-  </ul>
 </emu-clause>
 
 <emu-annex id="sec-why-not-template-literals">

--- a/spec.emu
+++ b/spec.emu
@@ -91,7 +91,7 @@ render(dropdown);
     </emu-grammar>
 
     <emu-note>
-      JSXIdentifier is different from Identifier, which means in the context of |Identifier[+await]|, you can still use <code>&lt;await /&gt;</code> as a JSX tag.
+      The grammar of |JSXIdentifier| is not parameterized the same way |Identifier| is. This means that <code>&lt;await /&gt;</code> is still a valid production when "[await]" appears during the derivation.
     </emu-note>
 
     <emu-grammar type="definition">
@@ -103,6 +103,17 @@ render(dropdown);
         JSXMemberExpression `.` JSXIdentifier
 
     </emu-grammar>
+
+    <emu-clause type="sdo" id="sec-jsx-elements-early-errors">
+      <h1>Static Semantics: Early Errors</h1>
+      <emu-grammar>
+        JSXElement : JSXOpeningElement JSXChildren? JSXClosingElement
+      </emu-grammar>
+      <ul>
+        <li>It is a Syntax Error if the source text matched by the |JSXElementName| of |JSXOpeningElement| does not equal to the source text matched by the |JSXElementName| of |JSXClosingElement|.</li>
+      </ul>
+    </emu-clause>
+
   </emu-clause>
 
   <emu-clause id="sec-jsx-attributes">
@@ -174,16 +185,6 @@ render(dropdown);
 
     </emu-grammar>
   </emu-clause>
-</emu-clause>
-
-<emu-clause type="sdo" id="sec-early-errors">
-  <h1>Static Semantics: Early Errors</h1>
-  <emu-grammar>
-    JSXElement : JSXOpeningElement JSXChildren? JSXClosingElement
-  </emu-grammar>
-  <ul>
-    <li>It is a Syntax Error if the source text matched by the |JSXElementName| of |JSXOpeningElement| does not equal to the source text matched by the |JSXElementName| of |JSXClosingElement|.</li>
-  </ul>
 </emu-clause>
 
 <emu-annex id="sec-why-not-template-literals">


### PR DESCRIPTION
Some improvements to #138

- move `SS: early error` specific to JSXElement production under `JSXElement` clause
- improve the phrasing on grammar parameterization.


cc @Jack-Works in case he has any inputs but I'll merge first to unblock #136 