### PR TITLE
Editorial: add a few missing type="definition"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1149,7 +1149,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 let sdoMap = JSON.parse(`{"prod-KCDyML_C":{"Early":{"clause":"1.2.1","ids":["prod-p4aAXPL4"]}}}`);
-let biblio = JSON.parse(`{"refsByClause":{"sec-jsx-string-characters":["_ref_0","_ref_60","_ref_61","_ref_62"],"sec-jsx-PrimaryExpression":["_ref_1","_ref_2"],"sec-jsx-elements":["_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_9","_ref_10","_ref_11","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23","_ref_24"],"sec-jsx-elements-early-errors":["_ref_25","_ref_26","_ref_27","_ref_28","_ref_29","_ref_30","_ref_31"],"sec-jsx-attributes":["_ref_32","_ref_33","_ref_34","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45","_ref_46","_ref_47","_ref_48","_ref_49","_ref_50"],"sec-jsx-children":["_ref_51","_ref_52","_ref_53","_ref_54","_ref_55","_ref_56","_ref_57","_ref_58","_ref_59"],"sec-HTMLCharacterReference":["_ref_63","_ref_64","_ref_65","_ref_66"],"sec-jsx-JSXString":["_ref_67","_ref_68","_ref_69"],"sec-jsx-JSXString-SV":["_ref_70","_ref_71","_ref_72","_ref_73"]},"entries":[{"type":"clause","id":"sec-rationale","titleHTML":"Rationale","number":""},{"type":"clause","id":"sec-intro","titleHTML":"Introduction","number":""},{"type":"clause","id":"sec-jsx-PrimaryExpression","titleHTML":"Modified Productions","number":"1.1"},{"type":"production","id":"prod-JSXElement","name":"JSXElement","referencingIds":["_ref_1","_ref_43","_ref_54"]},{"type":"production","id":"prod-JSXSelfClosingElement","name":"JSXSelfClosingElement","referencingIds":["_ref_3"]},{"type":"production","id":"prod-JSXOpeningElement","name":"JSXOpeningElement","referencingIds":["_ref_4","_ref_25","_ref_29"]},{"type":"production","id":"prod-JSXClosingElement","name":"JSXClosingElement","referencingIds":["_ref_6","_ref_27","_ref_31"]},{"type":"production","id":"prod-JSXFragment","name":"JSXFragment","referencingIds":["_ref_2","_ref_44","_ref_55"]},{"type":"production","id":"prod-JSXElementName","name":"JSXElementName","referencingIds":["_ref_7","_ref_9","_ref_11","_ref_28","_ref_30"]},{"type":"production","id":"prod-JSXIdentifier","name":"JSXIdentifier","referencingIds":["_ref_13","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_24","_ref_38"]},{"type":"production","id":"prod-JSXNamespacedName","name":"JSXNamespacedName","referencingIds":["_ref_14","_ref_39"]},{"type":"production","id":"prod-JSXMemberExpression","name":"JSXMemberExpression","referencingIds":["_ref_15","_ref_23"]},{"type":"clause","id":"sec-jsx-elements-early-errors","titleHTML":"Static Semantics: Early Errors","number":"1.2.1"},{"type":"clause","id":"sec-jsx-elements","titleHTML":"JSX Elements","number":"1.2"},{"type":"production","id":"prod-JSXAttributes","name":"JSXAttributes","referencingIds":["_ref_8","_ref_10","_ref_33","_ref_35"]},{"type":"production","id":"prod-JSXSpreadAttribute","name":"JSXSpreadAttribute","referencingIds":["_ref_32"]},{"type":"production","id":"prod-JSXAttribute","name":"JSXAttribute","referencingIds":["_ref_34"]},{"type":"production","id":"prod-JSXAttributeName","name":"JSXAttributeName","referencingIds":["_ref_36"]},{"type":"production","id":"prod-JSXAttributeInitializer","name":"JSXAttributeInitializer","referencingIds":["_ref_37"]},{"type":"production","id":"prod-JSXAttributeValue","name":"JSXAttributeValue","referencingIds":["_ref_40","_ref_60"]},{"type":"production","id":"prod-JSXDoubleStringCharacters","name":"JSXDoubleStringCharacters","referencingIds":["_ref_41","_ref_46","_ref_67"]},{"type":"production","id":"prod-JSXDoubleStringCharacter","name":"JSXDoubleStringCharacter","referencingIds":["_ref_45"]},{"type":"production","id":"prod-JSXSingleStringCharacters","name":"JSXSingleStringCharacters","referencingIds":["_ref_42","_ref_49","_ref_68"]},{"type":"production","id":"prod-JSXSingleStringCharacter","name":"JSXSingleStringCharacter","referencingIds":["_ref_48"]},{"type":"clause","id":"sec-jsx-attributes","titleHTML":"JSX Attributes","number":"1.3"},{"type":"production","id":"prod-JSXChildren","name":"JSXChildren","referencingIds":["_ref_5","_ref_12","_ref_26","_ref_52"]},{"type":"production","id":"prod-JSXChild","name":"JSXChild","referencingIds":["_ref_51"]},{"type":"production","id":"prod-JSXText","name":"JSXText","referencingIds":["_ref_53","_ref_58","_ref_61","_ref_69"]},{"type":"production","id":"prod-JSXTextCharacter","name":"JSXTextCharacter","referencingIds":["_ref_57"]},{"type":"production","id":"prod-JSXChildExpression","name":"JSXChildExpression","referencingIds":["_ref_56"]},{"type":"clause","id":"sec-jsx-children","titleHTML":"JSX Children","number":"1.4"},{"type":"production","id":"prod-JSXStringCharacter","name":"JSXStringCharacter","referencingIds":["_ref_47","_ref_50","_ref_59","_ref_71"]},{"type":"clause","id":"sec-jsx-string-characters","titleHTML":"JSX String Characters","number":"1.5.1"},{"type":"production","id":"prod-HTMLCharacterReference","name":"HTMLCharacterReference","referencingIds":["_ref_62"]},{"type":"production","id":"prod-HTMLDecimalCharacterReference","name":"HTMLDecimalCharacterReference","referencingIds":["_ref_63"]},{"type":"production","id":"prod-HTMLHexCharacterReference","name":"HTMLHexCharacterReference","referencingIds":["_ref_64"]},{"type":"production","id":"prod-HTMLNamedCharacterReference","name":"HTMLNamedCharacterReference","referencingIds":["_ref_65"]},{"type":"production","id":"prod-HTMLNamedCharacterReferenceName","name":"HTMLNamedCharacterReferenceName","referencingIds":["_ref_66","_ref_72","_ref_73"]},{"type":"clause","id":"sec-HTMLCharacterReference","titleHTML":"HTML Character References","number":"1.5.2","referencingIds":["_ref_0"]},{"type":"production","id":"prod-JSXString","name":"JSXString","referencingIds":["_ref_70"]},{"type":"clause","id":"sec-jsx-JSXString-SV","titleHTML":"Static Semantics: SV","number":"1.5.3.1"},{"type":"clause","id":"sec-jsx-JSXString","titleHTML":"JSX String Definition","number":"1.5.3"},{"type":"clause","id":"sec-jsx-string","titleHTML":"JSX Strings","number":"1.5"},{"type":"clause","id":"sec-jsx","titleHTML":"JSX Definition","number":"1"},{"type":"clause","id":"sec-why-not-template-literals","titleHTML":"Why not Template Literals?","number":"A"},{"type":"clause","id":"sec-why-not-JXON","titleHTML":"Why not JXON?","number":"B"},{"type":"clause","id":"sec-prior-art","titleHTML":"Prior Art","number":"C"},{"type":"clause","id":"sec-license","titleHTML":"License","number":"D"}]}`);
+let biblio = JSON.parse(`{"refsByClause":{"sec-jsx-string-characters":["_ref_0","_ref_57","_ref_58"],"sec-jsx-PrimaryExpression":["_ref_1","_ref_2"],"sec-jsx-elements":["_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_9","_ref_10","_ref_11","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23","_ref_24"],"sec-jsx-elements-early-errors":["_ref_25","_ref_26","_ref_27","_ref_28","_ref_29","_ref_30","_ref_31"],"sec-jsx-attributes":["_ref_32","_ref_33","_ref_34","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45","_ref_46","_ref_47","_ref_48"],"sec-jsx-children":["_ref_49","_ref_50","_ref_51","_ref_52","_ref_53","_ref_54","_ref_55","_ref_56"],"sec-jsx-JSXString":["_ref_59","_ref_60","_ref_61"]},"entries":[{"type":"clause","id":"sec-rationale","titleHTML":"Rationale","number":""},{"type":"clause","id":"sec-intro","titleHTML":"Introduction","number":""},{"type":"clause","id":"sec-jsx-PrimaryExpression","titleHTML":"Modified Productions","number":"1.1"},{"type":"production","id":"prod-JSXElement","name":"JSXElement","referencingIds":["_ref_1","_ref_43","_ref_52"]},{"type":"production","id":"prod-JSXSelfClosingElement","name":"JSXSelfClosingElement","referencingIds":["_ref_3"]},{"type":"production","id":"prod-JSXOpeningElement","name":"JSXOpeningElement","referencingIds":["_ref_4","_ref_25","_ref_29"]},{"type":"production","id":"prod-JSXClosingElement","name":"JSXClosingElement","referencingIds":["_ref_6","_ref_27","_ref_31"]},{"type":"production","id":"prod-JSXFragment","name":"JSXFragment","referencingIds":["_ref_2","_ref_44","_ref_53"]},{"type":"production","id":"prod-JSXElementName","name":"JSXElementName","referencingIds":["_ref_7","_ref_9","_ref_11","_ref_28","_ref_30"]},{"type":"production","id":"prod-JSXIdentifier","name":"JSXIdentifier","referencingIds":["_ref_13","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_24","_ref_38"]},{"type":"production","id":"prod-JSXNamespacedName","name":"JSXNamespacedName","referencingIds":["_ref_14","_ref_39"]},{"type":"production","id":"prod-JSXMemberExpression","name":"JSXMemberExpression","referencingIds":["_ref_15","_ref_23"]},{"type":"clause","id":"sec-jsx-elements-early-errors","titleHTML":"Static Semantics: Early Errors","number":"1.2.1"},{"type":"clause","id":"sec-jsx-elements","titleHTML":"JSX Elements","number":"1.2"},{"type":"production","id":"prod-JSXAttributes","name":"JSXAttributes","referencingIds":["_ref_8","_ref_10","_ref_33","_ref_35"]},{"type":"production","id":"prod-JSXSpreadAttribute","name":"JSXSpreadAttribute","referencingIds":["_ref_32"]},{"type":"production","id":"prod-JSXAttribute","name":"JSXAttribute","referencingIds":["_ref_34"]},{"type":"production","id":"prod-JSXAttributeName","name":"JSXAttributeName","referencingIds":["_ref_36"]},{"type":"production","id":"prod-JSXAttributeInitializer","name":"JSXAttributeInitializer","referencingIds":["_ref_37"]},{"type":"production","id":"prod-JSXAttributeValue","name":"JSXAttributeValue","referencingIds":["_ref_40","_ref_57"]},{"type":"production","id":"prod-JSXDoubleStringCharacters","name":"JSXDoubleStringCharacters","referencingIds":["_ref_41","_ref_46","_ref_59"]},{"type":"production","id":"prod-JSXDoubleStringCharacter","name":"JSXDoubleStringCharacter","referencingIds":["_ref_45"]},{"type":"production","id":"prod-JSXSingleStringCharacters","name":"JSXSingleStringCharacters","referencingIds":["_ref_42","_ref_48","_ref_60"]},{"type":"production","id":"prod-JSXSingleStringCharacter","name":"JSXSingleStringCharacter","referencingIds":["_ref_47"]},{"type":"clause","id":"sec-jsx-attributes","titleHTML":"JSX Attributes","number":"1.3"},{"type":"production","id":"prod-JSXChildren","name":"JSXChildren","referencingIds":["_ref_5","_ref_12","_ref_26","_ref_50"]},{"type":"production","id":"prod-JSXChild","name":"JSXChild","referencingIds":["_ref_49"]},{"type":"production","id":"prod-JSXText","name":"JSXText","referencingIds":["_ref_51","_ref_56","_ref_58","_ref_61"]},{"type":"production","id":"prod-JSXTextCharacter","name":"JSXTextCharacter","referencingIds":["_ref_55"]},{"type":"production","id":"prod-JSXChildExpression","name":"JSXChildExpression","referencingIds":["_ref_54"]},{"type":"clause","id":"sec-jsx-children","titleHTML":"JSX Children","number":"1.4"},{"type":"clause","id":"sec-jsx-string-characters","titleHTML":"JSX String Characters","number":"1.5.1"},{"type":"clause","id":"sec-HTMLCharacterReference","titleHTML":"HTML Character References","number":"1.5.2","referencingIds":["_ref_0"]},{"type":"clause","id":"sec-jsx-JSXString-SV","titleHTML":"Static Semantics: SV","number":"1.5.3.1"},{"type":"clause","id":"sec-jsx-JSXString","titleHTML":"JSX String Definition","number":"1.5.3"},{"type":"clause","id":"sec-jsx-string","titleHTML":"JSX Strings","number":"1.5"},{"type":"clause","id":"sec-jsx","titleHTML":"JSX Definition","number":"1"},{"type":"clause","id":"sec-why-not-template-literals","titleHTML":"Why not Template Literals?","number":"A"},{"type":"clause","id":"sec-why-not-JXON","titleHTML":"Why not JXON?","number":"B"},{"type":"clause","id":"sec-prior-art","titleHTML":"Prior Art","number":"C"},{"type":"clause","id":"sec-license","titleHTML":"License","number":"D"}]}`);
 ;let usesMultipage = false</script><style>body {
   display: flex;
   font-size: 18px;
@@ -2414,7 +2414,7 @@ li.menu-search-result-term:before {
 </ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
       <title>Menu</title>
       <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
-    </svg></div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intro" title="Introduction">Introduction</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-rationale" title="Rationale">Rationale</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-jsx" title="JSX Definition"><span class="secnum">1</span> JSX Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-PrimaryExpression" title="Modified Productions"><span class="secnum">1.1</span> Modified Productions</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-elements" title="JSX Elements"><span class="secnum">1.2</span> JSX Elements</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-elements-early-errors" title="Static Semantics: Early Errors"><span class="secnum">1.2.1</span> SS: Early Errors</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-attributes" title="JSX Attributes"><span class="secnum">1.3</span> JSX Attributes</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-children" title="JSX Children"><span class="secnum">1.4</span> JSX Children</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-string" title="JSX Strings"><span class="secnum">1.5</span> JSX Strings</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-string-characters" title="JSX String Characters"><span class="secnum">1.5.1</span> JSX String Characters</a></li><li><span class="item-toggle-none"></span><a href="#sec-HTMLCharacterReference" title="HTML Character References"><span class="secnum">1.5.2</span> HTML Character References</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-JSXString" title="JSX String Definition"><span class="secnum">1.5.3</span> JSX String Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-JSXString-SV" title="Static Semantics: SV"><span class="secnum">1.5.3.1</span> SS: SV</a></li></ol></li></ol></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-template-literals" title="Why not Template Literals?"><span class="secnum">A</span> Why not Template Literals?</a></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-JXON" title="Why not JXON?"><span class="secnum">B</span> Why not JXON?</a></li><li><span class="item-toggle-none"></span><a href="#sec-prior-art" title="Prior Art"><span class="secnum">C</span> Prior Art</a></li><li><span class="item-toggle-none"></span><a href="#sec-license" title="License"><span class="secnum">D</span> License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Draft / July 18, 2022</h1><h1 class="title">JSX</h1>
+    </svg></div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intro" title="Introduction">Introduction</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-rationale" title="Rationale">Rationale</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-jsx" title="JSX Definition"><span class="secnum">1</span> JSX Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-PrimaryExpression" title="Modified Productions"><span class="secnum">1.1</span> Modified Productions</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-elements" title="JSX Elements"><span class="secnum">1.2</span> JSX Elements</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-elements-early-errors" title="Static Semantics: Early Errors"><span class="secnum">1.2.1</span> SS: Early Errors</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-attributes" title="JSX Attributes"><span class="secnum">1.3</span> JSX Attributes</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-children" title="JSX Children"><span class="secnum">1.4</span> JSX Children</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-string" title="JSX Strings"><span class="secnum">1.5</span> JSX Strings</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-string-characters" title="JSX String Characters"><span class="secnum">1.5.1</span> JSX String Characters</a></li><li><span class="item-toggle-none"></span><a href="#sec-HTMLCharacterReference" title="HTML Character References"><span class="secnum">1.5.2</span> HTML Character References</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-JSXString" title="JSX String Definition"><span class="secnum">1.5.3</span> JSX String Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-JSXString-SV" title="Static Semantics: SV"><span class="secnum">1.5.3.1</span> SS: SV</a></li></ol></li></ol></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-template-literals" title="Why not Template Literals?"><span class="secnum">A</span> Why not Template Literals?</a></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-JXON" title="Why not JXON?"><span class="secnum">B</span> Why not JXON?</a></li><li><span class="item-toggle-none"></span><a href="#sec-prior-art" title="Prior Art"><span class="secnum">C</span> Prior Art</a></li><li><span class="item-toggle-none"></span><a href="#sec-license" title="License"><span class="secnum">D</span> License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Draft / March 8, 2022</h1><h1 class="title">JSX</h1>
 
 <emu-intro id="sec-intro">
   <h1>Introduction</h1>
@@ -2634,16 +2634,16 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXDoubleStringCharacter" type="lexical" id="prod-JSXDoubleStringCharacter">
-    <emu-nt><a href="#prod-JSXDoubleStringCharacter">JSXDoubleStringCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="nfdqsh-q"><emu-nt id="_ref_47"><a href="#prod-JSXStringCharacter">JSXStringCharacter</a></emu-nt> <emu-gmod>but not <emu-t>"</emu-t></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-JSXDoubleStringCharacter">JSXDoubleStringCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="nfdqsh-q"><emu-nt>JSXStringCharacter</emu-nt> <emu-gmod>but not <emu-t>"</emu-t></emu-gmod></emu-rhs>
 </emu-production>
 <emu-production name="JSXSingleStringCharacters" type="lexical" id="prod-JSXSingleStringCharacters">
     <emu-nt><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="xebljaxt">
-        <emu-nt id="_ref_48"><a href="#prod-JSXSingleStringCharacter">JSXSingleStringCharacter</a></emu-nt>
-        <emu-nt optional="" id="_ref_49"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_47"><a href="#prod-JSXSingleStringCharacter">JSXSingleStringCharacter</a></emu-nt>
+        <emu-nt optional="" id="_ref_48"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXSingleStringCharacter" type="lexical" id="prod-JSXSingleStringCharacter">
-    <emu-nt><a href="#prod-JSXSingleStringCharacter">JSXSingleStringCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="rqns83ga"><emu-nt id="_ref_50"><a href="#prod-JSXStringCharacter">JSXStringCharacter</a></emu-nt> <emu-gmod>but not <emu-t>'</emu-t></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-JSXSingleStringCharacter">JSXSingleStringCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="rqns83ga"><emu-nt>JSXStringCharacter</emu-nt> <emu-gmod>but not <emu-t>'</emu-t></emu-gmod></emu-rhs>
 </emu-production>
 </emu-grammar>
   </emu-clause>
@@ -2654,28 +2654,28 @@ li.menu-search-result-term:before {
 
     <emu-grammar type="definition"><emu-production name="JSXChildren" id="prod-JSXChildren">
     <emu-nt><a href="#prod-JSXChildren">JSXChildren</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ey07n052">
-        <emu-nt id="_ref_51"><a href="#prod-JSXChild">JSXChild</a></emu-nt>
-        <emu-nt optional="" id="_ref_52"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_49"><a href="#prod-JSXChild">JSXChild</a></emu-nt>
+        <emu-nt optional="" id="_ref_50"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXChild" id="prod-JSXChild">
-    <emu-nt><a href="#prod-JSXChild">JSXChild</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="iwpkswln"><emu-nt id="_ref_53"><a href="#prod-JSXText">JSXText</a></emu-nt></emu-rhs>
-    <emu-rhs a="ylbqkuqt"><emu-nt id="_ref_54"><a href="#prod-JSXElement">JSXElement</a></emu-nt></emu-rhs>
-    <emu-rhs a="xcc8tnvu"><emu-nt id="_ref_55"><a href="#prod-JSXFragment">JSXFragment</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-JSXChild">JSXChild</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="iwpkswln"><emu-nt id="_ref_51"><a href="#prod-JSXText">JSXText</a></emu-nt></emu-rhs>
+    <emu-rhs a="ylbqkuqt"><emu-nt id="_ref_52"><a href="#prod-JSXElement">JSXElement</a></emu-nt></emu-rhs>
+    <emu-rhs a="xcc8tnvu"><emu-nt id="_ref_53"><a href="#prod-JSXFragment">JSXFragment</a></emu-nt></emu-rhs>
     <emu-rhs a="7t9rmusx">
         <emu-t>{</emu-t>
-        <emu-nt optional="" id="_ref_56"><a href="#prod-JSXChildExpression">JSXChildExpression</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_54"><a href="#prod-JSXChildExpression">JSXChildExpression</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXText" type="lexical" id="prod-JSXText">
     <emu-nt><a href="#prod-JSXText">JSXText</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="z5eumfmp">
-        <emu-nt id="_ref_57"><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt>
-        <emu-nt optional="" id="_ref_58"><a href="#prod-JSXText">JSXText</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_55"><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt>
+        <emu-nt optional="" id="_ref_56"><a href="#prod-JSXText">JSXText</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXTextCharacter" type="lexical" id="prod-JSXTextCharacter">
-    <emu-nt><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="r679bmul"><emu-nt id="_ref_59"><a href="#prod-JSXStringCharacter">JSXStringCharacter</a></emu-nt> <emu-gmod>but not one of <emu-t>{</emu-t> or <emu-t>&lt;</emu-t> or <emu-t>&gt;</emu-t> or <emu-t>}</emu-t></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="r679bmul"><emu-nt>JSXStringCharacter</emu-nt> <emu-gmod>but not one of <emu-t>{</emu-t> or <emu-t>&lt;</emu-t> or <emu-t>&gt;</emu-t> or <emu-t>}</emu-t></emu-gmod></emu-rhs>
 </emu-production>
 <emu-production name="JSXChildExpression" id="prod-JSXChildExpression">
     <emu-nt><a href="#prod-JSXChildExpression">JSXChildExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="1px9pijq"><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt></emu-rhs>
@@ -2694,12 +2694,12 @@ li.menu-search-result-term:before {
     <emu-clause id="sec-jsx-string-characters">
       <h1><span class="secnum">1.5.1</span> JSX String Characters</h1>
 
-      <p>Historically, string characters within <emu-nt id="_ref_60"><a href="#prod-JSXAttributeValue">JSXAttributeValue</a></emu-nt> and <emu-nt id="_ref_61"><a href="#prod-JSXText">JSXText</a></emu-nt> are extended to allow the presence of <emu-xref href="#sec-HTMLCharacterReference" id="_ref_0"><a href="#sec-HTMLCharacterReference">HTML character references</a></emu-xref> to make copy-pasting between HTML and JSX easier, at the cost of not supporting <code>\</code> <emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-EscapeSequence">EscapeSequence</a></emu-nt> of ECMAScript's <emu-nt><a href="https://tc39.es/ecma262/#prod-StringLiteral">StringLiteral</a></emu-nt>. We may revisit this decision in the future.</p>
+      <p>Historically, string characters within <emu-nt id="_ref_57"><a href="#prod-JSXAttributeValue">JSXAttributeValue</a></emu-nt> and <emu-nt id="_ref_58"><a href="#prod-JSXText">JSXText</a></emu-nt> are extended to allow the presence of <emu-xref href="#sec-HTMLCharacterReference" id="_ref_0"><a href="#sec-HTMLCharacterReference">HTML character references</a></emu-xref> to make copy-pasting between HTML and JSX easier, at the cost of not supporting <code>\</code> <emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-EscapeSequence">EscapeSequence</a></emu-nt> of ECMAScript's <emu-nt><a href="https://tc39.es/ecma262/#prod-StringLiteral">StringLiteral</a></emu-nt>. We may revisit this decision in the future.</p>
       
       <h2>Syntax</h2>
 
-      <emu-grammar type="definition"><emu-production name="JSXStringCharacter" type="lexical" id="prod-JSXStringCharacter">
-    <emu-nt><a href="#prod-JSXStringCharacter">JSXStringCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="uudq6psd"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not one of <emu-nt id="_ref_62"><a href="#prod-HTMLCharacterReference">HTMLCharacterReference</a></emu-nt></emu-gmod></emu-rhs>
+      <emu-grammar><emu-production name="JSXStringCharacter" type="lexical">
+    <emu-nt>JSXStringCharacter</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="uudq6psd"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not one of <emu-nt>HTMLCharacterReference</emu-nt></emu-gmod></emu-rhs>
 </emu-production>
 </emu-grammar>
     </emu-clause>
@@ -2712,13 +2712,13 @@ li.menu-search-result-term:before {
 
       <h2>Syntax</h2>
 
-      <emu-grammar type="definition"><emu-production name="HTMLCharacterReference" type="lexical" id="prod-HTMLCharacterReference">
-    <emu-nt><a href="#prod-HTMLCharacterReference">HTMLCharacterReference</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="agxgawzs"><emu-nt id="_ref_63"><a href="#prod-HTMLDecimalCharacterReference">HTMLDecimalCharacterReference</a></emu-nt></emu-rhs>
-    <emu-rhs a="y8kdlbqm"><emu-nt id="_ref_64"><a href="#prod-HTMLHexCharacterReference">HTMLHexCharacterReference</a></emu-nt></emu-rhs>
-    <emu-rhs a="87f0wv7v"><emu-nt id="_ref_65"><a href="#prod-HTMLNamedCharacterReference">HTMLNamedCharacterReference</a></emu-nt></emu-rhs>
+      <emu-grammar><emu-production name="HTMLCharacterReference" type="lexical">
+    <emu-nt>HTMLCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="agxgawzs"><emu-nt>HTMLDecimalCharacterReference</emu-nt></emu-rhs>
+    <emu-rhs a="y8kdlbqm"><emu-nt>HTMLHexCharacterReference</emu-nt></emu-rhs>
+    <emu-rhs a="87f0wv7v"><emu-nt>HTMLNamedCharacterReference</emu-nt></emu-rhs>
 </emu-production>
-<emu-production name="HTMLDecimalCharacterReference" type="lexical" id="prod-HTMLDecimalCharacterReference">
-    <emu-nt><a href="#prod-HTMLDecimalCharacterReference">HTMLDecimalCharacterReference</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="fo85v5rn">
+<emu-production name="HTMLDecimalCharacterReference" type="lexical">
+    <emu-nt>HTMLDecimalCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="fo85v5rn">
         <emu-t>&amp;</emu-t>
         <emu-t>#</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>
@@ -2726,8 +2726,8 @@ li.menu-search-result-term:before {
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production>
-<emu-production name="HTMLHexCharacterReference" type="lexical" id="prod-HTMLHexCharacterReference">
-    <emu-nt><a href="#prod-HTMLHexCharacterReference">HTMLHexCharacterReference</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="d9cf0zze">
+<emu-production name="HTMLHexCharacterReference" type="lexical">
+    <emu-nt>HTMLHexCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="d9cf0zze">
         <emu-t>&amp;</emu-t>
         <emu-t>#</emu-t>
         <emu-t>x</emu-t>
@@ -2736,15 +2736,15 @@ li.menu-search-result-term:before {
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production>
-<emu-production name="HTMLNamedCharacterReference" type="lexical" id="prod-HTMLNamedCharacterReference">
-    <emu-nt><a href="#prod-HTMLNamedCharacterReference">HTMLNamedCharacterReference</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="er91pyag">
+<emu-production name="HTMLNamedCharacterReference" type="lexical">
+    <emu-nt>HTMLNamedCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="er91pyag">
         <emu-t>&amp;</emu-t>
-        <emu-nt id="_ref_66"><a href="#prod-HTMLNamedCharacterReferenceName">HTMLNamedCharacterReferenceName</a></emu-nt>
+        <emu-nt>HTMLNamedCharacterReferenceName</emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production>
-<emu-production name="HTMLNamedCharacterReferenceName" type="lexical" id="prod-HTMLNamedCharacterReferenceName">
-    <emu-nt><a href="#prod-HTMLNamedCharacterReferenceName">HTMLNamedCharacterReferenceName</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="dhbeeq7h"><emu-gprose>List of 252 character entity references defined in HTML4 standard</emu-gprose></emu-rhs>
+<emu-production name="HTMLNamedCharacterReferenceName" type="lexical">
+    <emu-nt>HTMLNamedCharacterReferenceName</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="dhbeeq7h"><emu-gprose>List of 252 character entity references defined in HTML4 standard</emu-gprose></emu-rhs>
 </emu-production>
 </emu-grammar>
 
@@ -2762,27 +2762,27 @@ li.menu-search-result-term:before {
     <emu-clause id="sec-jsx-JSXString">
       <h1><span class="secnum">1.5.3</span> JSX String Definition</h1>
       <h2>Syntax</h2>
-      <emu-grammar type="definition"><emu-production name="JSXString" id="prod-JSXString">
-    <emu-nt><a href="#prod-JSXString">JSXString</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="a4zlsky9"><emu-nt id="_ref_67"><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a></emu-nt></emu-rhs>
-    <emu-rhs a="mk2bi2rf"><emu-nt id="_ref_68"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a></emu-nt></emu-rhs>
-    <emu-rhs a="iwpkswln"><emu-nt id="_ref_69"><a href="#prod-JSXText">JSXText</a></emu-nt></emu-rhs>
+      <emu-grammar><emu-production name="JSXString">
+    <emu-nt>JSXString</emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="a4zlsky9"><emu-nt id="_ref_59"><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a></emu-nt></emu-rhs>
+    <emu-rhs a="mk2bi2rf"><emu-nt id="_ref_60"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a></emu-nt></emu-rhs>
+    <emu-rhs a="iwpkswln"><emu-nt id="_ref_61"><a href="#prod-JSXText">JSXText</a></emu-nt></emu-rhs>
 </emu-production>
 </emu-grammar>
 
       <emu-clause type="sdo" id="sec-jsx-JSXString-SV">
         <h1><span class="secnum">1.5.3.1</span> Static Semantics: SV</h1>
-        <p>An implementation may convert <emu-nt id="_ref_70"><a href="#prod-JSXString">JSXString</a></emu-nt> into a ECMAScript String value. In order to do this, JSX extends the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operation</a></emu-xref> <a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a> to <emu-nt id="_ref_71"><a href="#prod-JSXStringCharacter">JSXStringCharacter</a></emu-nt>:</p> 
+        <p>An implementation may convert <emu-nt>JSXString</emu-nt> into a ECMAScript String value. In order to do this, JSX extends the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operation</a></emu-xref> <a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a> to <emu-nt>JSXStringCharacter</emu-nt>:</p> 
         <ins class="block">
           <ul>
             <li>
                 The SV of <emu-grammar><emu-production name="JSXStringCharacter" type="lexical" collapsed="" class=" inline">
-    <emu-nt><a href="#prod-JSXStringCharacter">JSXStringCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="v3ewaosn"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt></emu-rhs>
+    <emu-nt>JSXStringCharacter</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="v3ewaosn"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt></emu-rhs>
 </emu-production>
 </emu-grammar> is the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code point matched by <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt>.
             </li>
             <li>
                 The SV of <emu-grammar><emu-production name="HTMLDecimalCharacterReference" type="lexical" collapsed="" class=" inline">
-    <emu-nt><a href="#prod-HTMLDecimalCharacterReference">HTMLDecimalCharacterReference</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="gdsompvk">
+    <emu-nt>HTMLDecimalCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="gdsompvk">
         <emu-t>&amp;</emu-t>
         <emu-t>#</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>
@@ -2793,7 +2793,7 @@ li.menu-search-result-term:before {
             </li>
             <li>
                 The SV of <emu-grammar><emu-production name="HTMLHexCharacterReference" type="lexical" collapsed="" class=" inline">
-    <emu-nt><a href="#prod-HTMLHexCharacterReference">HTMLHexCharacterReference</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="e4w_lnw7">
+    <emu-nt>HTMLHexCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="e4w_lnw7">
         <emu-t>&amp;</emu-t>
         <emu-t>#</emu-t>
         <emu-t>x</emu-t>
@@ -2805,13 +2805,13 @@ li.menu-search-result-term:before {
             </li>
             <li>
                 The SV of <emu-grammar><emu-production name="HTMLNamedCharacterReference" type="lexical" collapsed="" class=" inline">
-    <emu-nt><a href="#prod-HTMLNamedCharacterReference">HTMLNamedCharacterReference</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="er91pyag">
+    <emu-nt>HTMLNamedCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="er91pyag">
         <emu-t>&amp;</emu-t>
-        <emu-nt id="_ref_72"><a href="#prod-HTMLNamedCharacterReferenceName">HTMLNamedCharacterReferenceName</a></emu-nt>
+        <emu-nt>HTMLNamedCharacterReferenceName</emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production>
-</emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code points matched by <emu-nt id="_ref_73"><a href="#prod-HTMLNamedCharacterReferenceName">HTMLNamedCharacterReferenceName</a></emu-nt> according the implementation-defined list of names.
+</emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code points matched by <emu-nt>HTMLNamedCharacterReferenceName</emu-nt> according the implementation-defined list of names.
             </li>
           </ul>
         </ins>

--- a/index.html
+++ b/index.html
@@ -1149,7 +1149,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 let sdoMap = JSON.parse(`{"prod-KCDyML_C":{"Early":{"clause":"1.2.1","ids":["prod-p4aAXPL4"]}}}`);
-let biblio = JSON.parse(`{"refsByClause":{"sec-jsx-string-characters":["_ref_0","_ref_57","_ref_58"],"sec-jsx-PrimaryExpression":["_ref_1","_ref_2"],"sec-jsx-elements":["_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_9","_ref_10","_ref_11","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23","_ref_24"],"sec-jsx-elements-early-errors":["_ref_25","_ref_26","_ref_27","_ref_28","_ref_29","_ref_30","_ref_31"],"sec-jsx-attributes":["_ref_32","_ref_33","_ref_34","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45","_ref_46","_ref_47","_ref_48"],"sec-jsx-children":["_ref_49","_ref_50","_ref_51","_ref_52","_ref_53","_ref_54","_ref_55","_ref_56"],"sec-jsx-JSXString":["_ref_59","_ref_60","_ref_61"]},"entries":[{"type":"clause","id":"sec-rationale","titleHTML":"Rationale","number":""},{"type":"clause","id":"sec-intro","titleHTML":"Introduction","number":""},{"type":"clause","id":"sec-jsx-PrimaryExpression","titleHTML":"Modified Productions","number":"1.1"},{"type":"production","id":"prod-JSXElement","name":"JSXElement","referencingIds":["_ref_1","_ref_43","_ref_52"]},{"type":"production","id":"prod-JSXSelfClosingElement","name":"JSXSelfClosingElement","referencingIds":["_ref_3"]},{"type":"production","id":"prod-JSXOpeningElement","name":"JSXOpeningElement","referencingIds":["_ref_4","_ref_25","_ref_29"]},{"type":"production","id":"prod-JSXClosingElement","name":"JSXClosingElement","referencingIds":["_ref_6","_ref_27","_ref_31"]},{"type":"production","id":"prod-JSXFragment","name":"JSXFragment","referencingIds":["_ref_2","_ref_44","_ref_53"]},{"type":"production","id":"prod-JSXElementName","name":"JSXElementName","referencingIds":["_ref_7","_ref_9","_ref_11","_ref_28","_ref_30"]},{"type":"production","id":"prod-JSXIdentifier","name":"JSXIdentifier","referencingIds":["_ref_13","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_24","_ref_38"]},{"type":"production","id":"prod-JSXNamespacedName","name":"JSXNamespacedName","referencingIds":["_ref_14","_ref_39"]},{"type":"production","id":"prod-JSXMemberExpression","name":"JSXMemberExpression","referencingIds":["_ref_15","_ref_23"]},{"type":"clause","id":"sec-jsx-elements-early-errors","titleHTML":"Static Semantics: Early Errors","number":"1.2.1"},{"type":"clause","id":"sec-jsx-elements","titleHTML":"JSX Elements","number":"1.2"},{"type":"production","id":"prod-JSXAttributes","name":"JSXAttributes","referencingIds":["_ref_8","_ref_10","_ref_33","_ref_35"]},{"type":"production","id":"prod-JSXSpreadAttribute","name":"JSXSpreadAttribute","referencingIds":["_ref_32"]},{"type":"production","id":"prod-JSXAttribute","name":"JSXAttribute","referencingIds":["_ref_34"]},{"type":"production","id":"prod-JSXAttributeName","name":"JSXAttributeName","referencingIds":["_ref_36"]},{"type":"production","id":"prod-JSXAttributeInitializer","name":"JSXAttributeInitializer","referencingIds":["_ref_37"]},{"type":"production","id":"prod-JSXAttributeValue","name":"JSXAttributeValue","referencingIds":["_ref_40","_ref_57"]},{"type":"production","id":"prod-JSXDoubleStringCharacters","name":"JSXDoubleStringCharacters","referencingIds":["_ref_41","_ref_46","_ref_59"]},{"type":"production","id":"prod-JSXDoubleStringCharacter","name":"JSXDoubleStringCharacter","referencingIds":["_ref_45"]},{"type":"production","id":"prod-JSXSingleStringCharacters","name":"JSXSingleStringCharacters","referencingIds":["_ref_42","_ref_48","_ref_60"]},{"type":"production","id":"prod-JSXSingleStringCharacter","name":"JSXSingleStringCharacter","referencingIds":["_ref_47"]},{"type":"clause","id":"sec-jsx-attributes","titleHTML":"JSX Attributes","number":"1.3"},{"type":"production","id":"prod-JSXChildren","name":"JSXChildren","referencingIds":["_ref_5","_ref_12","_ref_26","_ref_50"]},{"type":"production","id":"prod-JSXChild","name":"JSXChild","referencingIds":["_ref_49"]},{"type":"production","id":"prod-JSXText","name":"JSXText","referencingIds":["_ref_51","_ref_56","_ref_58","_ref_61"]},{"type":"production","id":"prod-JSXTextCharacter","name":"JSXTextCharacter","referencingIds":["_ref_55"]},{"type":"production","id":"prod-JSXChildExpression","name":"JSXChildExpression","referencingIds":["_ref_54"]},{"type":"clause","id":"sec-jsx-children","titleHTML":"JSX Children","number":"1.4"},{"type":"clause","id":"sec-jsx-string-characters","titleHTML":"JSX String Characters","number":"1.5.1"},{"type":"clause","id":"sec-HTMLCharacterReference","titleHTML":"HTML Character References","number":"1.5.2","referencingIds":["_ref_0"]},{"type":"clause","id":"sec-jsx-JSXString-SV","titleHTML":"Static Semantics: SV","number":"1.5.3.1"},{"type":"clause","id":"sec-jsx-JSXString","titleHTML":"JSX String Definition","number":"1.5.3"},{"type":"clause","id":"sec-jsx-string","titleHTML":"JSX Strings","number":"1.5"},{"type":"clause","id":"sec-jsx","titleHTML":"JSX Definition","number":"1"},{"type":"clause","id":"sec-why-not-template-literals","titleHTML":"Why not Template Literals?","number":"A"},{"type":"clause","id":"sec-why-not-JXON","titleHTML":"Why not JXON?","number":"B"},{"type":"clause","id":"sec-prior-art","titleHTML":"Prior Art","number":"C"},{"type":"clause","id":"sec-license","titleHTML":"License","number":"D"}]}`);
+let biblio = JSON.parse(`{"refsByClause":{"sec-jsx-string-characters":["_ref_0","_ref_60","_ref_61","_ref_62"],"sec-jsx-PrimaryExpression":["_ref_1","_ref_2"],"sec-jsx-elements":["_ref_3","_ref_4","_ref_5","_ref_6","_ref_7","_ref_8","_ref_9","_ref_10","_ref_11","_ref_12","_ref_13","_ref_14","_ref_15","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_23","_ref_24"],"sec-jsx-elements-early-errors":["_ref_25","_ref_26","_ref_27","_ref_28","_ref_29","_ref_30","_ref_31"],"sec-jsx-attributes":["_ref_32","_ref_33","_ref_34","_ref_35","_ref_36","_ref_37","_ref_38","_ref_39","_ref_40","_ref_41","_ref_42","_ref_43","_ref_44","_ref_45","_ref_46","_ref_47","_ref_48","_ref_49","_ref_50"],"sec-jsx-children":["_ref_51","_ref_52","_ref_53","_ref_54","_ref_55","_ref_56","_ref_57","_ref_58","_ref_59"],"sec-HTMLCharacterReference":["_ref_63","_ref_64","_ref_65","_ref_66"],"sec-jsx-JSXString":["_ref_67","_ref_68","_ref_69"],"sec-jsx-JSXString-SV":["_ref_70","_ref_71","_ref_72","_ref_73"]},"entries":[{"type":"clause","id":"sec-rationale","titleHTML":"Rationale","number":""},{"type":"clause","id":"sec-intro","titleHTML":"Introduction","number":""},{"type":"clause","id":"sec-jsx-PrimaryExpression","titleHTML":"Modified Productions","number":"1.1"},{"type":"production","id":"prod-JSXElement","name":"JSXElement","referencingIds":["_ref_1","_ref_43","_ref_54"]},{"type":"production","id":"prod-JSXSelfClosingElement","name":"JSXSelfClosingElement","referencingIds":["_ref_3"]},{"type":"production","id":"prod-JSXOpeningElement","name":"JSXOpeningElement","referencingIds":["_ref_4","_ref_25","_ref_29"]},{"type":"production","id":"prod-JSXClosingElement","name":"JSXClosingElement","referencingIds":["_ref_6","_ref_27","_ref_31"]},{"type":"production","id":"prod-JSXFragment","name":"JSXFragment","referencingIds":["_ref_2","_ref_44","_ref_55"]},{"type":"production","id":"prod-JSXElementName","name":"JSXElementName","referencingIds":["_ref_7","_ref_9","_ref_11","_ref_28","_ref_30"]},{"type":"production","id":"prod-JSXIdentifier","name":"JSXIdentifier","referencingIds":["_ref_13","_ref_16","_ref_17","_ref_18","_ref_19","_ref_20","_ref_21","_ref_22","_ref_24","_ref_38"]},{"type":"production","id":"prod-JSXNamespacedName","name":"JSXNamespacedName","referencingIds":["_ref_14","_ref_39"]},{"type":"production","id":"prod-JSXMemberExpression","name":"JSXMemberExpression","referencingIds":["_ref_15","_ref_23"]},{"type":"clause","id":"sec-jsx-elements-early-errors","titleHTML":"Static Semantics: Early Errors","number":"1.2.1"},{"type":"clause","id":"sec-jsx-elements","titleHTML":"JSX Elements","number":"1.2"},{"type":"production","id":"prod-JSXAttributes","name":"JSXAttributes","referencingIds":["_ref_8","_ref_10","_ref_33","_ref_35"]},{"type":"production","id":"prod-JSXSpreadAttribute","name":"JSXSpreadAttribute","referencingIds":["_ref_32"]},{"type":"production","id":"prod-JSXAttribute","name":"JSXAttribute","referencingIds":["_ref_34"]},{"type":"production","id":"prod-JSXAttributeName","name":"JSXAttributeName","referencingIds":["_ref_36"]},{"type":"production","id":"prod-JSXAttributeInitializer","name":"JSXAttributeInitializer","referencingIds":["_ref_37"]},{"type":"production","id":"prod-JSXAttributeValue","name":"JSXAttributeValue","referencingIds":["_ref_40","_ref_60"]},{"type":"production","id":"prod-JSXDoubleStringCharacters","name":"JSXDoubleStringCharacters","referencingIds":["_ref_41","_ref_46","_ref_67"]},{"type":"production","id":"prod-JSXDoubleStringCharacter","name":"JSXDoubleStringCharacter","referencingIds":["_ref_45"]},{"type":"production","id":"prod-JSXSingleStringCharacters","name":"JSXSingleStringCharacters","referencingIds":["_ref_42","_ref_49","_ref_68"]},{"type":"production","id":"prod-JSXSingleStringCharacter","name":"JSXSingleStringCharacter","referencingIds":["_ref_48"]},{"type":"clause","id":"sec-jsx-attributes","titleHTML":"JSX Attributes","number":"1.3"},{"type":"production","id":"prod-JSXChildren","name":"JSXChildren","referencingIds":["_ref_5","_ref_12","_ref_26","_ref_52"]},{"type":"production","id":"prod-JSXChild","name":"JSXChild","referencingIds":["_ref_51"]},{"type":"production","id":"prod-JSXText","name":"JSXText","referencingIds":["_ref_53","_ref_58","_ref_61","_ref_69"]},{"type":"production","id":"prod-JSXTextCharacter","name":"JSXTextCharacter","referencingIds":["_ref_57"]},{"type":"production","id":"prod-JSXChildExpression","name":"JSXChildExpression","referencingIds":["_ref_56"]},{"type":"clause","id":"sec-jsx-children","titleHTML":"JSX Children","number":"1.4"},{"type":"production","id":"prod-JSXStringCharacter","name":"JSXStringCharacter","referencingIds":["_ref_47","_ref_50","_ref_59","_ref_71"]},{"type":"clause","id":"sec-jsx-string-characters","titleHTML":"JSX String Characters","number":"1.5.1"},{"type":"production","id":"prod-HTMLCharacterReference","name":"HTMLCharacterReference","referencingIds":["_ref_62"]},{"type":"production","id":"prod-HTMLDecimalCharacterReference","name":"HTMLDecimalCharacterReference","referencingIds":["_ref_63"]},{"type":"production","id":"prod-HTMLHexCharacterReference","name":"HTMLHexCharacterReference","referencingIds":["_ref_64"]},{"type":"production","id":"prod-HTMLNamedCharacterReference","name":"HTMLNamedCharacterReference","referencingIds":["_ref_65"]},{"type":"production","id":"prod-HTMLNamedCharacterReferenceName","name":"HTMLNamedCharacterReferenceName","referencingIds":["_ref_66","_ref_72","_ref_73"]},{"type":"clause","id":"sec-HTMLCharacterReference","titleHTML":"HTML Character References","number":"1.5.2","referencingIds":["_ref_0"]},{"type":"production","id":"prod-JSXString","name":"JSXString","referencingIds":["_ref_70"]},{"type":"clause","id":"sec-jsx-JSXString-SV","titleHTML":"Static Semantics: SV","number":"1.5.3.1"},{"type":"clause","id":"sec-jsx-JSXString","titleHTML":"JSX String Definition","number":"1.5.3"},{"type":"clause","id":"sec-jsx-string","titleHTML":"JSX Strings","number":"1.5"},{"type":"clause","id":"sec-jsx","titleHTML":"JSX Definition","number":"1"},{"type":"clause","id":"sec-why-not-template-literals","titleHTML":"Why not Template Literals?","number":"A"},{"type":"clause","id":"sec-why-not-JXON","titleHTML":"Why not JXON?","number":"B"},{"type":"clause","id":"sec-prior-art","titleHTML":"Prior Art","number":"C"},{"type":"clause","id":"sec-license","titleHTML":"License","number":"D"}]}`);
 ;let usesMultipage = false</script><style>body {
   display: flex;
   font-size: 18px;
@@ -2414,7 +2414,7 @@ li.menu-search-result-term:before {
 </ul></div><div id="menu-toggle"><svg xmlns="http://www.w3.org/2000/svg" style="width:100%; height:100%; stroke:currentColor" viewBox="0 0 120 120">
       <title>Menu</title>
       <path stroke-width="10" stroke-linecap="round" d="M30,60 h60  M30,30 m0,5 h60  M30,90 m0,-5 h60"></path>
-    </svg></div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intro" title="Introduction">Introduction</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-rationale" title="Rationale">Rationale</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-jsx" title="JSX Definition"><span class="secnum">1</span> JSX Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-PrimaryExpression" title="Modified Productions"><span class="secnum">1.1</span> Modified Productions</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-elements" title="JSX Elements"><span class="secnum">1.2</span> JSX Elements</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-elements-early-errors" title="Static Semantics: Early Errors"><span class="secnum">1.2.1</span> SS: Early Errors</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-attributes" title="JSX Attributes"><span class="secnum">1.3</span> JSX Attributes</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-children" title="JSX Children"><span class="secnum">1.4</span> JSX Children</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-string" title="JSX Strings"><span class="secnum">1.5</span> JSX Strings</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-string-characters" title="JSX String Characters"><span class="secnum">1.5.1</span> JSX String Characters</a></li><li><span class="item-toggle-none"></span><a href="#sec-HTMLCharacterReference" title="HTML Character References"><span class="secnum">1.5.2</span> HTML Character References</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-JSXString" title="JSX String Definition"><span class="secnum">1.5.3</span> JSX String Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-JSXString-SV" title="Static Semantics: SV"><span class="secnum">1.5.3.1</span> SS: SV</a></li></ol></li></ol></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-template-literals" title="Why not Template Literals?"><span class="secnum">A</span> Why not Template Literals?</a></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-JXON" title="Why not JXON?"><span class="secnum">B</span> Why not JXON?</a></li><li><span class="item-toggle-none"></span><a href="#sec-prior-art" title="Prior Art"><span class="secnum">C</span> Prior Art</a></li><li><span class="item-toggle-none"></span><a href="#sec-license" title="License"><span class="secnum">D</span> License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Draft / March 8, 2022</h1><h1 class="title">JSX</h1>
+    </svg></div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intro" title="Introduction">Introduction</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-rationale" title="Rationale">Rationale</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-jsx" title="JSX Definition"><span class="secnum">1</span> JSX Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-PrimaryExpression" title="Modified Productions"><span class="secnum">1.1</span> Modified Productions</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-elements" title="JSX Elements"><span class="secnum">1.2</span> JSX Elements</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-elements-early-errors" title="Static Semantics: Early Errors"><span class="secnum">1.2.1</span> SS: Early Errors</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-attributes" title="JSX Attributes"><span class="secnum">1.3</span> JSX Attributes</a></li><li><span class="item-toggle-none"></span><a href="#sec-jsx-children" title="JSX Children"><span class="secnum">1.4</span> JSX Children</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-string" title="JSX Strings"><span class="secnum">1.5</span> JSX Strings</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-string-characters" title="JSX String Characters"><span class="secnum">1.5.1</span> JSX String Characters</a></li><li><span class="item-toggle-none"></span><a href="#sec-HTMLCharacterReference" title="HTML Character References"><span class="secnum">1.5.2</span> HTML Character References</a></li><li><span class="item-toggle">◢</span><a href="#sec-jsx-JSXString" title="JSX String Definition"><span class="secnum">1.5.3</span> JSX String Definition</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-jsx-JSXString-SV" title="Static Semantics: SV"><span class="secnum">1.5.3.1</span> SS: SV</a></li></ol></li></ol></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-template-literals" title="Why not Template Literals?"><span class="secnum">A</span> Why not Template Literals?</a></li><li><span class="item-toggle-none"></span><a href="#sec-why-not-JXON" title="Why not JXON?"><span class="secnum">B</span> Why not JXON?</a></li><li><span class="item-toggle-none"></span><a href="#sec-prior-art" title="Prior Art"><span class="secnum">C</span> Prior Art</a></li><li><span class="item-toggle-none"></span><a href="#sec-license" title="License"><span class="secnum">D</span> License</a></li></ol></div></div><div id="spec-container"><h1 class="version">Draft / July 18, 2022</h1><h1 class="title">JSX</h1>
 
 <emu-intro id="sec-intro">
   <h1>Introduction</h1>
@@ -2634,16 +2634,16 @@ li.menu-search-result-term:before {
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXDoubleStringCharacter" type="lexical" id="prod-JSXDoubleStringCharacter">
-    <emu-nt><a href="#prod-JSXDoubleStringCharacter">JSXDoubleStringCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="nfdqsh-q"><emu-nt>JSXStringCharacter</emu-nt> <emu-gmod>but not <emu-t>"</emu-t></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-JSXDoubleStringCharacter">JSXDoubleStringCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="nfdqsh-q"><emu-nt id="_ref_47"><a href="#prod-JSXStringCharacter">JSXStringCharacter</a></emu-nt> <emu-gmod>but not <emu-t>"</emu-t></emu-gmod></emu-rhs>
 </emu-production>
 <emu-production name="JSXSingleStringCharacters" type="lexical" id="prod-JSXSingleStringCharacters">
     <emu-nt><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="xebljaxt">
-        <emu-nt id="_ref_47"><a href="#prod-JSXSingleStringCharacter">JSXSingleStringCharacter</a></emu-nt>
-        <emu-nt optional="" id="_ref_48"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_48"><a href="#prod-JSXSingleStringCharacter">JSXSingleStringCharacter</a></emu-nt>
+        <emu-nt optional="" id="_ref_49"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXSingleStringCharacter" type="lexical" id="prod-JSXSingleStringCharacter">
-    <emu-nt><a href="#prod-JSXSingleStringCharacter">JSXSingleStringCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="rqns83ga"><emu-nt>JSXStringCharacter</emu-nt> <emu-gmod>but not <emu-t>'</emu-t></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-JSXSingleStringCharacter">JSXSingleStringCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="rqns83ga"><emu-nt id="_ref_50"><a href="#prod-JSXStringCharacter">JSXStringCharacter</a></emu-nt> <emu-gmod>but not <emu-t>'</emu-t></emu-gmod></emu-rhs>
 </emu-production>
 </emu-grammar>
   </emu-clause>
@@ -2654,28 +2654,28 @@ li.menu-search-result-term:before {
 
     <emu-grammar type="definition"><emu-production name="JSXChildren" id="prod-JSXChildren">
     <emu-nt><a href="#prod-JSXChildren">JSXChildren</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="ey07n052">
-        <emu-nt id="_ref_49"><a href="#prod-JSXChild">JSXChild</a></emu-nt>
-        <emu-nt optional="" id="_ref_50"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_51"><a href="#prod-JSXChild">JSXChild</a></emu-nt>
+        <emu-nt optional="" id="_ref_52"><a href="#prod-JSXChildren">JSXChildren</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXChild" id="prod-JSXChild">
-    <emu-nt><a href="#prod-JSXChild">JSXChild</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="iwpkswln"><emu-nt id="_ref_51"><a href="#prod-JSXText">JSXText</a></emu-nt></emu-rhs>
-    <emu-rhs a="ylbqkuqt"><emu-nt id="_ref_52"><a href="#prod-JSXElement">JSXElement</a></emu-nt></emu-rhs>
-    <emu-rhs a="xcc8tnvu"><emu-nt id="_ref_53"><a href="#prod-JSXFragment">JSXFragment</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-JSXChild">JSXChild</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="iwpkswln"><emu-nt id="_ref_53"><a href="#prod-JSXText">JSXText</a></emu-nt></emu-rhs>
+    <emu-rhs a="ylbqkuqt"><emu-nt id="_ref_54"><a href="#prod-JSXElement">JSXElement</a></emu-nt></emu-rhs>
+    <emu-rhs a="xcc8tnvu"><emu-nt id="_ref_55"><a href="#prod-JSXFragment">JSXFragment</a></emu-nt></emu-rhs>
     <emu-rhs a="7t9rmusx">
         <emu-t>{</emu-t>
-        <emu-nt optional="" id="_ref_54"><a href="#prod-JSXChildExpression">JSXChildExpression</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt optional="" id="_ref_56"><a href="#prod-JSXChildExpression">JSXChildExpression</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
         <emu-t>}</emu-t>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXText" type="lexical" id="prod-JSXText">
     <emu-nt><a href="#prod-JSXText">JSXText</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="z5eumfmp">
-        <emu-nt id="_ref_55"><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt>
-        <emu-nt optional="" id="_ref_56"><a href="#prod-JSXText">JSXText</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
+        <emu-nt id="_ref_57"><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt>
+        <emu-nt optional="" id="_ref_58"><a href="#prod-JSXText">JSXText</a><emu-mods><emu-opt>opt</emu-opt></emu-mods></emu-nt>
     </emu-rhs>
 </emu-production>
 <emu-production name="JSXTextCharacter" type="lexical" id="prod-JSXTextCharacter">
-    <emu-nt><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="r679bmul"><emu-nt>JSXStringCharacter</emu-nt> <emu-gmod>but not one of <emu-t>{</emu-t> or <emu-t>&lt;</emu-t> or <emu-t>&gt;</emu-t> or <emu-t>}</emu-t></emu-gmod></emu-rhs>
+    <emu-nt><a href="#prod-JSXTextCharacter">JSXTextCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="r679bmul"><emu-nt id="_ref_59"><a href="#prod-JSXStringCharacter">JSXStringCharacter</a></emu-nt> <emu-gmod>but not one of <emu-t>{</emu-t> or <emu-t>&lt;</emu-t> or <emu-t>&gt;</emu-t> or <emu-t>}</emu-t></emu-gmod></emu-rhs>
 </emu-production>
 <emu-production name="JSXChildExpression" id="prod-JSXChildExpression">
     <emu-nt><a href="#prod-JSXChildExpression">JSXChildExpression</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="1px9pijq"><emu-nt><a href="https://tc39.es/ecma262/#prod-AssignmentExpression">AssignmentExpression</a></emu-nt></emu-rhs>
@@ -2694,12 +2694,12 @@ li.menu-search-result-term:before {
     <emu-clause id="sec-jsx-string-characters">
       <h1><span class="secnum">1.5.1</span> JSX String Characters</h1>
 
-      <p>Historically, string characters within <emu-nt id="_ref_57"><a href="#prod-JSXAttributeValue">JSXAttributeValue</a></emu-nt> and <emu-nt id="_ref_58"><a href="#prod-JSXText">JSXText</a></emu-nt> are extended to allow the presence of <emu-xref href="#sec-HTMLCharacterReference" id="_ref_0"><a href="#sec-HTMLCharacterReference">HTML character references</a></emu-xref> to make copy-pasting between HTML and JSX easier, at the cost of not supporting <code>\</code> <emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-EscapeSequence">EscapeSequence</a></emu-nt> of ECMAScript's <emu-nt><a href="https://tc39.es/ecma262/#prod-StringLiteral">StringLiteral</a></emu-nt>. We may revisit this decision in the future.</p>
+      <p>Historically, string characters within <emu-nt id="_ref_60"><a href="#prod-JSXAttributeValue">JSXAttributeValue</a></emu-nt> and <emu-nt id="_ref_61"><a href="#prod-JSXText">JSXText</a></emu-nt> are extended to allow the presence of <emu-xref href="#sec-HTMLCharacterReference" id="_ref_0"><a href="#sec-HTMLCharacterReference">HTML character references</a></emu-xref> to make copy-pasting between HTML and JSX easier, at the cost of not supporting <code>\</code> <emu-nt><a href="https://tc39.es/ecma262/#prod-annexB-EscapeSequence">EscapeSequence</a></emu-nt> of ECMAScript's <emu-nt><a href="https://tc39.es/ecma262/#prod-StringLiteral">StringLiteral</a></emu-nt>. We may revisit this decision in the future.</p>
       
       <h2>Syntax</h2>
 
-      <emu-grammar><emu-production name="JSXStringCharacter" type="lexical">
-    <emu-nt>JSXStringCharacter</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="uudq6psd"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not one of <emu-nt>HTMLCharacterReference</emu-nt></emu-gmod></emu-rhs>
+      <emu-grammar type="definition"><emu-production name="JSXStringCharacter" type="lexical" id="prod-JSXStringCharacter">
+    <emu-nt><a href="#prod-JSXStringCharacter">JSXStringCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="uudq6psd"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt> <emu-gmod>but not one of <emu-nt id="_ref_62"><a href="#prod-HTMLCharacterReference">HTMLCharacterReference</a></emu-nt></emu-gmod></emu-rhs>
 </emu-production>
 </emu-grammar>
     </emu-clause>
@@ -2712,13 +2712,13 @@ li.menu-search-result-term:before {
 
       <h2>Syntax</h2>
 
-      <emu-grammar><emu-production name="HTMLCharacterReference" type="lexical">
-    <emu-nt>HTMLCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="agxgawzs"><emu-nt>HTMLDecimalCharacterReference</emu-nt></emu-rhs>
-    <emu-rhs a="y8kdlbqm"><emu-nt>HTMLHexCharacterReference</emu-nt></emu-rhs>
-    <emu-rhs a="87f0wv7v"><emu-nt>HTMLNamedCharacterReference</emu-nt></emu-rhs>
+      <emu-grammar type="definition"><emu-production name="HTMLCharacterReference" type="lexical" id="prod-HTMLCharacterReference">
+    <emu-nt><a href="#prod-HTMLCharacterReference">HTMLCharacterReference</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="agxgawzs"><emu-nt id="_ref_63"><a href="#prod-HTMLDecimalCharacterReference">HTMLDecimalCharacterReference</a></emu-nt></emu-rhs>
+    <emu-rhs a="y8kdlbqm"><emu-nt id="_ref_64"><a href="#prod-HTMLHexCharacterReference">HTMLHexCharacterReference</a></emu-nt></emu-rhs>
+    <emu-rhs a="87f0wv7v"><emu-nt id="_ref_65"><a href="#prod-HTMLNamedCharacterReference">HTMLNamedCharacterReference</a></emu-nt></emu-rhs>
 </emu-production>
-<emu-production name="HTMLDecimalCharacterReference" type="lexical">
-    <emu-nt>HTMLDecimalCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="fo85v5rn">
+<emu-production name="HTMLDecimalCharacterReference" type="lexical" id="prod-HTMLDecimalCharacterReference">
+    <emu-nt><a href="#prod-HTMLDecimalCharacterReference">HTMLDecimalCharacterReference</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="fo85v5rn">
         <emu-t>&amp;</emu-t>
         <emu-t>#</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>
@@ -2726,8 +2726,8 @@ li.menu-search-result-term:before {
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production>
-<emu-production name="HTMLHexCharacterReference" type="lexical">
-    <emu-nt>HTMLHexCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="d9cf0zze">
+<emu-production name="HTMLHexCharacterReference" type="lexical" id="prod-HTMLHexCharacterReference">
+    <emu-nt><a href="#prod-HTMLHexCharacterReference">HTMLHexCharacterReference</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="d9cf0zze">
         <emu-t>&amp;</emu-t>
         <emu-t>#</emu-t>
         <emu-t>x</emu-t>
@@ -2736,15 +2736,15 @@ li.menu-search-result-term:before {
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production>
-<emu-production name="HTMLNamedCharacterReference" type="lexical">
-    <emu-nt>HTMLNamedCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="er91pyag">
+<emu-production name="HTMLNamedCharacterReference" type="lexical" id="prod-HTMLNamedCharacterReference">
+    <emu-nt><a href="#prod-HTMLNamedCharacterReference">HTMLNamedCharacterReference</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="er91pyag">
         <emu-t>&amp;</emu-t>
-        <emu-nt>HTMLNamedCharacterReferenceName</emu-nt>
+        <emu-nt id="_ref_66"><a href="#prod-HTMLNamedCharacterReferenceName">HTMLNamedCharacterReferenceName</a></emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production>
-<emu-production name="HTMLNamedCharacterReferenceName" type="lexical">
-    <emu-nt>HTMLNamedCharacterReferenceName</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="dhbeeq7h"><emu-gprose>List of 252 character entity references defined in HTML4 standard</emu-gprose></emu-rhs>
+<emu-production name="HTMLNamedCharacterReferenceName" type="lexical" id="prod-HTMLNamedCharacterReferenceName">
+    <emu-nt><a href="#prod-HTMLNamedCharacterReferenceName">HTMLNamedCharacterReferenceName</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="dhbeeq7h"><emu-gprose>List of 252 character entity references defined in HTML4 standard</emu-gprose></emu-rhs>
 </emu-production>
 </emu-grammar>
 
@@ -2762,27 +2762,27 @@ li.menu-search-result-term:before {
     <emu-clause id="sec-jsx-JSXString">
       <h1><span class="secnum">1.5.3</span> JSX String Definition</h1>
       <h2>Syntax</h2>
-      <emu-grammar><emu-production name="JSXString">
-    <emu-nt>JSXString</emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="a4zlsky9"><emu-nt id="_ref_59"><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a></emu-nt></emu-rhs>
-    <emu-rhs a="mk2bi2rf"><emu-nt id="_ref_60"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a></emu-nt></emu-rhs>
-    <emu-rhs a="iwpkswln"><emu-nt id="_ref_61"><a href="#prod-JSXText">JSXText</a></emu-nt></emu-rhs>
+      <emu-grammar type="definition"><emu-production name="JSXString" id="prod-JSXString">
+    <emu-nt><a href="#prod-JSXString">JSXString</a></emu-nt> <emu-geq>:</emu-geq> <emu-rhs a="a4zlsky9"><emu-nt id="_ref_67"><a href="#prod-JSXDoubleStringCharacters">JSXDoubleStringCharacters</a></emu-nt></emu-rhs>
+    <emu-rhs a="mk2bi2rf"><emu-nt id="_ref_68"><a href="#prod-JSXSingleStringCharacters">JSXSingleStringCharacters</a></emu-nt></emu-rhs>
+    <emu-rhs a="iwpkswln"><emu-nt id="_ref_69"><a href="#prod-JSXText">JSXText</a></emu-nt></emu-rhs>
 </emu-production>
 </emu-grammar>
 
       <emu-clause type="sdo" id="sec-jsx-JSXString-SV">
         <h1><span class="secnum">1.5.3.1</span> Static Semantics: SV</h1>
-        <p>An implementation may convert <emu-nt>JSXString</emu-nt> into a ECMAScript String value. In order to do this, JSX extends the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operation</a></emu-xref> <a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a> to <emu-nt>JSXStringCharacter</emu-nt>:</p> 
+        <p>An implementation may convert <emu-nt id="_ref_70"><a href="#prod-JSXString">JSXString</a></emu-nt> into a ECMAScript String value. In order to do this, JSX extends the <emu-xref href="#sec-algorithm-conventions-syntax-directed-operations"><a href="https://tc39.es/ecma262/#sec-algorithm-conventions-syntax-directed-operations">syntax-directed operation</a></emu-xref> <a href="https://tc39.es/ecma262/#sec-static-semantics-sv">SV</a> to <emu-nt id="_ref_71"><a href="#prod-JSXStringCharacter">JSXStringCharacter</a></emu-nt>:</p> 
         <ins class="block">
           <ul>
             <li>
                 The SV of <emu-grammar><emu-production name="JSXStringCharacter" type="lexical" collapsed="" class=" inline">
-    <emu-nt>JSXStringCharacter</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="v3ewaosn"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt></emu-rhs>
+    <emu-nt><a href="#prod-JSXStringCharacter">JSXStringCharacter</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="v3ewaosn"><emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt></emu-rhs>
 </emu-production>
 </emu-grammar> is the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code point matched by <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-SourceCharacter">SourceCharacter</a></emu-nt>.
             </li>
             <li>
                 The SV of <emu-grammar><emu-production name="HTMLDecimalCharacterReference" type="lexical" collapsed="" class=" inline">
-    <emu-nt>HTMLDecimalCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="gdsompvk">
+    <emu-nt><a href="#prod-HTMLDecimalCharacterReference">HTMLDecimalCharacterReference</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="gdsompvk">
         <emu-t>&amp;</emu-t>
         <emu-t>#</emu-t>
         <emu-nt><a href="https://tc39.es/ecma262/#prod-grammar-notation-DecimalDigits">DecimalDigits</a></emu-nt>
@@ -2793,7 +2793,7 @@ li.menu-search-result-term:before {
             </li>
             <li>
                 The SV of <emu-grammar><emu-production name="HTMLHexCharacterReference" type="lexical" collapsed="" class=" inline">
-    <emu-nt>HTMLHexCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="e4w_lnw7">
+    <emu-nt><a href="#prod-HTMLHexCharacterReference">HTMLHexCharacterReference</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="e4w_lnw7">
         <emu-t>&amp;</emu-t>
         <emu-t>#</emu-t>
         <emu-t>x</emu-t>
@@ -2805,13 +2805,13 @@ li.menu-search-result-term:before {
             </li>
             <li>
                 The SV of <emu-grammar><emu-production name="HTMLNamedCharacterReference" type="lexical" collapsed="" class=" inline">
-    <emu-nt>HTMLNamedCharacterReference</emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="er91pyag">
+    <emu-nt><a href="#prod-HTMLNamedCharacterReference">HTMLNamedCharacterReference</a></emu-nt> <emu-geq>::</emu-geq> <emu-rhs a="er91pyag">
         <emu-t>&amp;</emu-t>
-        <emu-nt>HTMLNamedCharacterReferenceName</emu-nt>
+        <emu-nt id="_ref_72"><a href="#prod-HTMLNamedCharacterReferenceName">HTMLNamedCharacterReferenceName</a></emu-nt>
         <emu-t>;</emu-t>
     </emu-rhs>
 </emu-production>
-</emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code points matched by <emu-nt>HTMLNamedCharacterReferenceName</emu-nt> according the implementation-defined list of names.
+</emu-grammar> is the same as the result of performing <a href="https://tc39.es/ecma262/#sec-utf16encodecodepoint">UTF16EncodeCodePoint</a> on the code points matched by <emu-nt id="_ref_73"><a href="#prod-HTMLNamedCharacterReferenceName">HTMLNamedCharacterReferenceName</a></emu-nt> according the implementation-defined list of names.
             </li>
           </ul>
         </ins>

--- a/spec.emu
+++ b/spec.emu
@@ -198,8 +198,8 @@ render(dropdown);
       
       <h2>Syntax</h2>
 
-      <emu-grammar>
-        JSXStringCharacter::
+      <emu-grammar type="definition">
+        JSXStringCharacter ::
           SourceCharacter but not one of HTMLCharacterReference
       </emu-grammar>
     </emu-clause>
@@ -212,7 +212,7 @@ render(dropdown);
 
       <h2>Syntax</h2>
 
-      <emu-grammar>
+      <emu-grammar type="definition">
         HTMLCharacterReference::
           HTMLDecimalCharacterReference
           HTMLHexCharacterReference
@@ -245,7 +245,7 @@ render(dropdown);
     <emu-clause id="sec-jsx-JSXString">
       <h1>JSX String Definition</h1>
       <h2>Syntax</h2>
-      <emu-grammar>
+      <emu-grammar type="definition">
         JSXString :
           JSXDoubleStringCharacters
           JSXSingleStringCharacters


### PR DESCRIPTION
There are a few nonterminals that are not linkable, e.g. `JSXString` (try https://facebook.github.io/jsx/#prod-JSXString on the current deployment). This is due to the missing `type="definition"` attr.

(I've built the index.html myself. Let me know if I need to revert that.)